### PR TITLE
feat(env): add env parameter to genLogMethods for global commit tagging

### DIFF
--- a/.behavior/v2026_05_08.gen-logs-env/.bind/vlad.gen-logs-env.flag
+++ b/.behavior/v2026_05_08.gen-logs-env/.bind/vlad.gen-logs-env.flag
@@ -1,0 +1,2 @@
+branch: vlad/gen-logs-env
+bound_by: init.behavior skill

--- a/.behavior/v2026_05_08.gen-logs-env/.route/.bind.vlad.gen-logs-env.flag
+++ b/.behavior/v2026_05_08.gen-logs-env/.route/.bind.vlad.gen-logs-env.flag
@@ -1,0 +1,2 @@
+branch: vlad/gen-logs-env
+bound_by: route.bind skill

--- a/.behavior/v2026_05_08.gen-logs-env/.route/.gitignore
+++ b/.behavior/v2026_05_08.gen-logs-env/.route/.gitignore
@@ -1,0 +1,5 @@
+# ignore all except passage.jsonl and .bind flags
+*
+!.gitignore
+!passage.jsonl
+!.bind.*

--- a/.behavior/v2026_05_08.gen-logs-env/.route/passage.jsonl
+++ b/.behavior/v2026_05_08.gen-logs-env/.route/passage.jsonl
@@ -1,0 +1,12 @@
+{"stone":"1.vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-grounded-in-reality"}
+{"stone":"1.vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-questioned-questions"}
+{"stone":"1.vision","status":"blocked","blocker":"approval","reason":"wait for human approval"}
+{"stone":"1.vision","status":"approved"}
+{"stone":"1.vision","status":"passed"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-pruned-yagni"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-pruned-backcompat"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.self","reason":"review.self required: role-standards-coverage"}
+{"stone":"5.1.execution.from_vision","status":"passed"}
+{"stone":"5.3.verification","status":"blocked","blocker":"review.self","reason":"review.self required: has-behavior-coverage"}
+{"stone":"5.3.verification","status":"blocked","blocker":"review.self","reason":"review.self required: has-snap-changes-rationalized"}
+{"stone":"5.3.verification","status":"passed"}

--- a/.behavior/v2026_05_08.gen-logs-env/0.wish.md
+++ b/.behavior/v2026_05_08.gen-logs-env/0.wish.md
@@ -1,0 +1,18 @@
+wish =
+
+genLogMethods needs to support global, trail-less env flags
+
+right now its only on genContextLogTrail
+
+but envs are global, so its possible to get a stable env across a global genLogMethods singleton
+
+unlike trails, which change as they flow through operations
+
+---
+
+so, keep the env available on genContextLogTrail. it can override the inner env
+
+but also allow env to be set via genLogMethods directly
+
+for users that want to set it globally too
+

--- a/.behavior/v2026_05_08.gen-logs-env/1.vision.guard
+++ b/.behavior/v2026_05_08.gen-logs-env/1.vision.guard
@@ -1,0 +1,87 @@
+# guard for vision stone
+#
+# requires human approval before stone can be marked as passed
+# because the self-review prompts require human feedback,
+# the process needs to halt here for human review
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route
+
+reviews:
+  self:
+    - slug: has-grounded-in-reality
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        did the junior ground the vision in reality, or make things up?
+
+        check the groundwork section:
+
+        for external references (APIs, services, docs):
+        - did they actually verify these exist?
+        - did they cite what they checked?
+        - or did they assume without sanity check?
+
+        for internal references (extant behavior, patterns, code):
+        - did they actually verify what that behavior is?
+        - did they verify extant contracts to conform to? (interfaces, types, signatures)
+        - did they verify extant vocab to reuse? (domain terms, name patterns)
+        - did they verify extant stdouts to match? (CLI output patterns, error formats)
+        - did they cite specific files/lines?
+        - or did they assume the code works a certain way without verification?
+
+        this is NOT about exhaustive research — just sanity checks.
+        the question is: is this vision coherent with reality, or built on assumptions?
+
+    - slug: has-questioned-requirements
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any requirements that should be questioned?
+
+        for each requirement, ask:
+        - who said this was needed? when? why?
+        - what evidence supports this requirement?
+        - what if we didn't do this — what would happen?
+        - is the scope too large, too small, or misdirected?
+        - could we achieve the goal in a simpler way?
+
+        challenge each requirement and justify why it belongs.
+
+    - slug: has-questioned-assumptions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any hidden assumptions the junior took as requirements?
+
+        for each assumption, ask:
+        - what do we assume here without evidence?
+        - what evidence supports this assumption?
+        - what if the opposite were true?
+        - did the wisher actually say this, or did we infer it?
+        - what exceptions or counterexamples exist?
+
+        surface all hidden assumptions and question each one.
+
+    - slug: has-questioned-questions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any open questions? triage them:
+
+        for each question, ask:
+        - can this be answered via logic now? if so, answer it now.
+        - can this be answered via extant docs or code now? if so, answer it now.
+        - should this be answered via external research later? if so, mark it for research.
+        - does only the wisher know the answer? if so, ask the wisher.
+
+        for each question, ensure it is clearly marked as either:
+        - [answered] — resolved now
+        - [research] — to be answered in the research phase
+        - [wisher] — requires wisher input
+
+        ensure they're enumerated within the vision under "open questions & assumptions"

--- a/.behavior/v2026_05_08.gen-logs-env/1.vision.stone
+++ b/.behavior/v2026_05_08.gen-logs-env/1.vision.stone
@@ -1,0 +1,70 @@
+illustrate the vision implied in the wish .behavior/v2026_05_08.gen-logs-env/0.wish.md
+
+emit into .behavior/v2026_05_08.gen-logs-env/1.vision.yield.md
+
+---
+
+paint a picture of what the world looks like when this wish is fulfilled
+
+testdrive the contract we propose via realworld examples
+
+specifically,
+
+## the outcome world
+
+- what does a day-in-the-life look like with this in place?
+- what's the before/after contrast?
+- what's the "aha" moment where the value clicks?
+
+## user experience
+
+- what usecases do folks fulfill? what goals?
+- what contract inputs & outputs do they leverage?
+- what would it look like to leverage them?
+- what timelines do they go through?
+
+## mental model
+
+- how would users describe this to a friend?
+- what analogies or metaphors fit?
+- what terms would they use vs what terms would we use?
+
+## evaluation
+
+- how well does it solve the goals?
+- what are the pros? the cons?
+- what edgecases exist and how do our contracts keep users in a pit of success?
+
+## open questions & assumptions
+
+- what assumptions have we made?
+- what questions remain unanswered?
+- what must we validate with the wisher before we proceed?
+- what must we research externally?
+
+## groundwork
+
+sanity check the vision against reality. NOT exhaustive research — just enough to know the vision isn't built on false assumptions.
+
+### external research
+
+if the wish references external APIs, services, or docs:
+- did you verify they exist and work the way you assume?
+- cite what you checked (links, key constraints noted)
+- if none referenced, say "none — no external dependencies"
+
+### internal research
+
+if the wish references extant behavior, patterns, or code:
+- did you verify what that behavior actually is?
+- contracts: interfaces, types, signatures to conform to
+- vocab: domain terms, name patterns to reuse
+- stdouts: CLI output patterns, error formats to match
+- cite what you checked (file paths, line numbers)
+- if none referenced, say "none — no extant behavior extended"
+
+## what is awkward?
+
+- what feels off or forced?
+- where does the design fight the user's mental model?
+- what tradeoffs feel uncomfortable?

--- a/.behavior/v2026_05_08.gen-logs-env/1.vision.yield.md
+++ b/.behavior/v2026_05_08.gen-logs-env/1.vision.yield.md
@@ -1,0 +1,235 @@
+# vision: genLogMethods with env support
+
+## the outcome world
+
+### before/after contrast
+
+**before:**
+```ts
+// global singleton — no env support
+export const log = genLogMethods({ level: { minimum: LogLevel.INFO } });
+
+// must use genContextLogTrail to get env.commit in logs
+// but genContextLogTrail requires trail, which is per-request
+// so you can't have a simple global logger with env
+```
+
+**after:**
+```ts
+import { getEnvironment } from 'sdk-environment';
+
+// global singleton WITH env baked in via sdk-environment
+const environment = getEnvironment.static();
+export const log = genLogMethods({
+  level: { minimum: LogLevel.INFO },
+  env: environment,
+});
+
+// every log automatically includes env.commit
+log.info('server started', { port: 3000 });
+// → { level: 'info', message: 'server started', metadata: { port: 3000 }, env: { commit: 'main@abc123' } }
+```
+
+### the "aha" moment
+
+> "i can pass `getEnvironment.static()` straight into `genLogMethods` and every log knows the commit — no ceremony"
+
+env is static at boot time. trail changes per-request. they shouldn't be coupled.
+
+### day-in-the-life
+
+1. dev sets up singleton: `const env = getEnvironment.static(); export const log = genLogMethods({ env })`
+2. imports `log` anywhere in codebase
+3. every log includes `env.commit` automatically
+4. when request correlation needed, wraps with `withLogTrail` — trail gets added, env stays
+5. in cloudwatch, can filter by commit to see logs from specific deploy
+
+---
+
+## user experience
+
+### usecases
+
+| usecase | contract | example |
+|---------|----------|---------|
+| global logger with commit | `genLogMethods({ env })` | `genLogMethods({ env: getEnvironment.static() })` |
+| per-request logger with trail | `genContextLogTrail({ trail, env })` | keeps work, env can override |
+| wrapped operation | `withLogTrail(fn)` | keeps work, inherits env from outer log |
+
+### contract: genLogMethods
+
+```ts
+import type { Environment } from 'sdk-environment';
+
+export const genLogMethods = ({
+  level,
+  outlets,
+  env,  // NEW
+}: {
+  level?: { minimum?: LogLevel };
+  outlets?: LogOutlet[];
+  env?: Partial<Environment> | null;  // NEW: any subset of Environment fields
+}) => LogMethods;
+```
+
+**integration with sdk-environment:**
+
+```ts
+import { getEnvironment } from 'sdk-environment';
+import { genLogMethods } from 'sdk-logs';
+
+const environment = getEnvironment.static();
+const log = genLogMethods({ env: environment });
+
+log.info('server started', { port: 3000 });
+// → includes env.commit from sdk-environment
+```
+
+### contract: genContextLogTrail (updated for consistency)
+
+```ts
+import type { Environment } from 'sdk-environment';
+
+export const genContextLogTrail = ({
+  trail,
+  env,
+  level,
+}: {
+  trail: { exid: string | null; stack: string[] } | null;
+  env: Partial<Environment> | null;  // UPDATED: same shape as genLogMethods
+  level?: { minimum?: LogLevel };  // UPDATED: same shape as genLogMethods
+}) => ContextLogTrail;
+```
+
+### timeline
+
+1. **boot time**: `genLogMethods({ env: { commit } })` creates global logger with env baked in
+2. **request time**: `genContextLogTrail` or `withLogTrail` adds trail, can override env
+3. **log time**: log includes env.commit (from global or override)
+
+---
+
+## mental model
+
+### how users would describe this
+
+> "i set the commit hash once at startup, and every log includes it. if i need request tracing too, i wrap with withLogTrail."
+
+### analogies
+
+- **env is like sdk-environment.getEnvironment.static()** — set once at boot, stable for lifetime
+- **trail is like request context** — changes per request, flows through operations
+- **genLogMethods is the factory** — can bake in stable config (level, outlets, env)
+- **genContextLogTrail is the contextualizer** — adds per-request context (trail), can override stable config
+
+### terms
+
+| we use | users might say |
+|--------|-----------------|
+| env.commit | "git sha", "version", "deploy hash" |
+| trail.exid | "trace id", "request id", "correlation id" |
+| genLogMethods | "create logger", "log factory" |
+
+---
+
+## evaluation
+
+### pros
+
+- **simple global loggers**: get env.commit without threading trail
+- **consistent with env semantics**: env is global, so setting it globally makes sense
+- **backwards compatible**: env is optional, extant code unchanged
+- **composable**: genContextLogTrail can still override env if needed
+
+### cons
+
+- **two places to set env**: could create confusion (genLogMethods vs genContextLogTrail)
+  - mitigated by: clear mental model (global vs per-request)
+  - override rule: genContextLogTrail env wins (more specific beats global)
+
+### edgecases
+
+| edge | behavior | pit of success |
+|------|----------|----------------|
+| env is null | log excludes env key | explicit null = intentional omission |
+| env not passed | log excludes env key | backwards compatible |
+| env is `{ commit }` only | works, logs commit | Partial<Environment> |
+| env is full Environment | works, logs commit | natural fit with getEnvironment.static() |
+| genContextLogTrail has env | per-request env wins | more specific beats global |
+| withLogTrail inherits env | uses outer log's env | composability preserved |
+
+### pit of success
+
+- `env: null` is explicit "no env" — prevents accidental omission
+- `env: { commit: null }` means "env exists but commit unknown" — different from no env
+- type system guides users to provide explicit values
+
+---
+
+## open questions & assumptions
+
+### assumptions
+
+1. **env uses Partial<Environment> from sdk-environment** — accepts any subset of fields
+2. **env is static at boot** — not mutated at runtime
+3. **genContextLogTrail env beats genLogMethods env** — per-request context wins over global config (more specific)
+4. **only env.commit is logged for now** — other fields available for future use
+
+### questions for wisher
+
+1. **[answered] should env be exposed on LogMethods?** — YES, expose `.env` for full withLogTrail composability
+   - `withLogTrail` reads `context.log.env` to propagate env to nested operations
+   - `LogMethods` currently doesn't expose `.env` — only `{ error, warn, info, debug, _ }`
+   - **decision:** add `.env` to LogMethods interface (option a)
+
+2. **[answered] should outlets receive env?** — YES, outlets should receive env
+   - current: `LogEvent = { level, timestamp, message, metadata }`
+   - **decision:** add env to LogEvent: `LogEvent = { level, timestamp, message, metadata, env? }`
+
+### external research
+
+**sdk-environment** — verified types for integration:
+- `Environment` type: `{ access, config, server, commit }`
+- `Partial<Environment>` accepts any subset: `{ commit }`, `{ commit, access }`, etc.
+- `getEnvironment.static()` returns full `Environment` synchronously
+- `EnvironmentCommitSlug` is `string` (format: `$gitref@$hash` or `$gitref@$hash+` if dirty)
+- source: `ehmpathy/sdk-environment` (npm: sdk-environment@0.1.3)
+
+### internal research
+
+verified extant contracts:
+- `genLogMethods.ts:48-54` — current signature takes `{ level, outlets }`
+- `genContextLogTrail.ts:11-38` — current signature takes `{ trail, env, minimalLogLevel }`
+- `generateLogMethod.ts:28-40` — already supports `env` parameter, just not exposed by `genLogMethods`
+- `package.json` — sdk-environment is NOT a current dependency; must add as peer dependency
+
+---
+
+## what is awkward?
+
+### withLogTrail composability gap
+
+the most awkward part: `withLogTrail` reads `context.log.env` to propagate env to nested operations. but `LogMethods` doesn't expose `.env`.
+
+if we just add `env` to genLogMethods input but don't expose it on the output, users get:
+- env in their direct logs (good)
+- but nested operations via withLogTrail won't inherit it (bad)
+
+**resolution:** add `.env` to `LogMethods` interface. this is the only way to get full composability.
+
+### two places to set env
+
+users might wonder: "do i set env on genLogMethods or genContextLogTrail?"
+
+**resolution:** clear guidance in docs:
+- genLogMethods env = global default, set once at boot
+- genContextLogTrail = full context with trail + env, use for per-request
+
+### env shape is Partial<Environment>
+
+uses `Partial<Environment>` from sdk-environment. this means:
+- users can pass full env: `getEnvironment.static()`
+- users can pass just commit: `{ commit: 'main@abc123' }`
+- users can pass any subset: `{ commit, access }`
+- natural fit with sdk-environment — no shape conversion needed
+- backwards compatible: `{ commit: 'abc123' }` still works

--- a/.behavior/v2026_05_08.gen-logs-env/5.1.execution.from_vision.guard
+++ b/.behavior/v2026_05_08.gen-logs-env/5.1.execution.from_vision.guard
@@ -1,0 +1,180 @@
+# guard for execution stone (from vision - nano size)
+# includes standardized self-review frame
+
+artifacts:
+  # track execution progress
+  - "$route/5.1.execution.from_vision.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    # 1. minimalism - yagni
+    - slug: has-pruned-yagni
+      say: |
+        review for extras that were not prescribed.
+
+        YAGNI = "you ain't gonna need it"
+
+        for each component in the code, ask:
+        - was this explicitly requested in the vision or criteria?
+        - is this the minimum viable way to satisfy the requirement?
+        - did we add abstraction "for future flexibility"?
+        - did we add features "while we're here"?
+        - did we optimize before we knew it was needed?
+
+        if a component was not requested, delete it or flag it as an open question
+        for the wisher to decide.
+
+    # 2. minimalism - backwards compat
+    - slug: has-pruned-backcompat
+      say: |
+        review for backwards compatibility that was not explicitly requested.
+
+        for each backwards-compat concern in the code, ask:
+        - did the wisher explicitly say to maintain this compatibility?
+        - is there evidence this backwards compat is needed?
+        - or did we assume it "to be safe"?
+
+        if backwards compat was not explicitly requested:
+        1. flag it as an open question for the wisher
+        2. eliminate it if not confirmed as required
+        3. make the open question very clearly reported
+
+    # 3. consistency - mechanisms
+    - slug: has-consistent-mechanisms
+      say: |
+        review for new mechanisms that duplicate extant functionality.
+
+        unless the ask was to refactor, be consistent with extant mechanisms.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). look for extant utilities and patterns.
+
+        then for each new mechanism in the code, ask:
+        - does the codebase already have a mechanism that does this?
+        - do we duplicate extant utilities or patterns?
+        - could we reuse an extant component instead of a new one?
+
+        if a new mechanism duplicates extant functionality:
+        1. replace with the extant mechanism
+        2. or flag as an open question if unsure
+
+    # 4. consistency - conventions
+    - slug: has-consistent-conventions
+      say: |
+        review for divergence from extant names and patterns.
+
+        unless the ask was to refactor, be consistent with extant conventions.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). identify extant name conventions and patterns.
+
+        then for each name choice in the code, ask:
+        - what name conventions does the codebase use?
+        - do we use a different namespace, prefix, or suffix pattern?
+        - do we introduce new terms when extant terms exist?
+        - does our structure match extant patterns?
+
+        if we diverge from extant conventions:
+        1. align with the extant convention
+        2. or flag as an open question if the extant convention seems wrong
+
+    # 5. review against behavior declaration - coverage
+    - slug: behavior-declaration-coverage
+      say: |
+        review for coverage of the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have omitted
+        requirements or left features unimplemented.
+
+        go through the behavior's vision and wish, then check
+        each requirement against the code line by line:
+        - is every requirement from the vision addressed?
+        - did the junior skip or forget any part of the spec?
+
+        fix all gaps before you continue.
+
+    # 6. review against behavior declaration - adherance
+    - slug: behavior-declaration-adherance
+      say: |
+        review for adherance to the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have drifted
+        from the spec or implemented items incorrectly.
+
+        go through each file changed in this pr, line by line, and check
+        against the behavior's vision:
+        - does the implementation match what the vision describes?
+        - did the junior misinterpret or deviate from the spec?
+
+        fix all gaps before you continue.
+
+    # 7. review against role standards - adherance
+    - slug: role-standards-adherance
+      say: |
+        review for adherance to mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have introduced
+        bad practices or violated patterns that we require.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - does the code follow mechanic standards correctly?
+        - are there violations of required patterns?
+        - did the junior introduce anti-patterns, bad practices, or deviations from our conventions?
+
+        fix all gaps before you continue.
+
+    # 8. review against role standards - coverage
+    - slug: role-standards-coverage
+      say: |
+        review for coverage of mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have forgotten
+        best practices or omitted patterns that should be present.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - are all relevant mechanic standards applied?
+        - are there patterns that should be present but are absent?
+        - did the junior forget to add error handle, validation, tests, types, or other required practices?
+
+        fix all gaps before you continue.
+
+  peer:
+    # slug = mech-failhides
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.mech-failhides.md'
+
+    # slug = mech-decode-friction
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '**/*.ts' --paths-without '**/*.test.ts' --join intersect --output '$route/.reviews/$stone.peer-review.mech-decode-friction.md'
+
+    # --- architect reviews ---
+    # lineage: $rhachet enroll claude --roles behaver,architect,mechanic -p "review the current implementation for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally. emit BLOCKERS and NITPICKS."
+    # slug = arch-opport-decomposition
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-opport-decomposition.md'
+    # slug = arch-smell-scopeleaks
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-smell-scopeleaks.md'
+    # slug = arch-hazards-maintenance
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-hazards-maintenance.md'
+    # slug = arch-hazards-behavior
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-hazards-behavior.md'
+
+    # lineage: $rhachet enroll claude --roles behaver,architect,mechanic -p "review the current implementation for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps. emit BLOCKERS and NITPICKS."
+    # slug = behavior-intent-coverage
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md' --refs '$route/0.wish.md' --refs '$route/1.vision.yield.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.criteria/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.behavior-intent-coverage.md'
+    # slug = ergo-friction-hazards
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-friction-hazards.md'
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3

--- a/.behavior/v2026_05_08.gen-logs-env/5.1.execution.from_vision.stone
+++ b/.behavior/v2026_05_08.gen-logs-env/5.1.execution.from_vision.stone
@@ -1,0 +1,15 @@
+bootup your mechanic's role via `./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic`
+
+then, execute the vision directly
+- .behavior/v2026_05_08.gen-logs-env/1.vision.md
+
+ref:
+- .behavior/v2026_05_08.gen-logs-env/0.wish.md
+
+
+---
+
+track your progress
+
+emit todos and check them off into
+- .behavior/v2026_05_08.gen-logs-env/5.1.execution.from_vision.yield.md

--- a/.behavior/v2026_05_08.gen-logs-env/5.1.execution.from_vision.yield.md
+++ b/.behavior/v2026_05_08.gen-logs-env/5.1.execution.from_vision.yield.md
@@ -1,0 +1,37 @@
+# execution: genLogMethods with env support
+
+## todos
+
+- [x] add sdk-environment as peer dependency
+- [x] update LogEvent to include env
+- [x] update generateLogMethod to pass env to outlets
+- [x] update LogMethods interface to expose .env
+- [x] update genLogMethods to accept env and expose it
+- [x] update genContextLogTrail to use Partial<Environment> and level
+- [x] run types check
+- [x] run unit tests (55 passed)
+- [ ] run integration tests (require AWS SSO auth - not code issue)
+
+## changes
+
+### production code
+
+| file | change |
+|------|--------|
+| package.json | added sdk-environment 0.1.3 |
+| LogOutlet.ts | added env?: Partial<Environment> to LogEvent |
+| genLogMethods.ts | added env param, exposed on LogMethods |
+| generateLogMethod.ts | env type changed to Partial<Environment> |
+| genContextLogTrail.ts | env type → Partial<Environment>, level: { minimum? } |
+| LogTrail.ts | env type → Partial<Environment> |
+| formatLogContentsForEnvironment.ts | env type → Partial<Environment> |
+| withLogTrail.ts | imported Environment, type → Partial<Environment> |
+
+### test code
+
+| file | change |
+|------|--------|
+| genContextLogTrail.all-log-levels.integration.test.ts | minimalLogLevel → level: { minimum } |
+| genContextLogTrail.test.ts | minimalLogLevel → level: { minimum }, commit: null → env: {} |
+| genContextLogTrail.commit-null.integration.test.ts | commit: null → env: {} |
+| withLogTrail.stack-growth.integration.test.ts | minimalLogLevel → level: { minimum } |

--- a/.behavior/v2026_05_08.gen-logs-env/5.3.verification.guard
+++ b/.behavior/v2026_05_08.gen-logs-env/5.3.verification.guard
@@ -1,0 +1,258 @@
+artifacts:
+  # track verification progress
+  - "$route/5.3.verification.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    - slug: has-behavior-coverage
+      say: |
+        double-check: does the verification checklist show every behavior from wish/vision has a test?
+
+        - is every behavior in 0.wish.md covered?
+        - is every behavior in 1.vision.md covered?
+        - can you point to each test file in the checklist?
+
+        **if any behavior lacks a test, write the test NOW.** do not pass this gate with gaps.
+
+    - slug: has-zero-test-skips
+      say: |
+        double-check: did you verify zero skips — and REMOVE any you found?
+
+        - no .skip() or .only() found?
+        - no silent credential bypasses?
+        - no prior failures carried forward?
+
+        **if you found skips, did you remove them and make those tests pass?**
+
+        this is buttonup. skips are gaps. gaps get fixed, not noted.
+
+    - slug: has-all-tests-passed
+      say: |
+        double-check: did all tests pass? prove it.
+
+        **zero unproven claims.** you must cite the exact command and output.
+
+        for each test suite:
+        - what command did you run?
+        - what was the exit code?
+        - how many tests passed?
+
+        example proof:
+        ```
+        $ npm run test:unit
+        > exit 0
+        > 47 tests passed
+        ```
+
+        if you cannot cite the command and output, you did not prove it.
+
+        zero tolerance for extant failures:
+        - "it was already broken" is not an excuse — fix it
+        - "it's unrelated to my changes" is not an excuse — fix it
+        - flaky tests must be stabilized, not tolerated
+        - every failure is your responsibility now
+
+        zero tolerance for fake tests:
+        - tests that always pass are fraud
+        - tests that mock the system under test prove nothingness
+        - tests must verify real behavior
+
+        zero tolerance for credential excuses:
+        - "i don't have creds" means get them or mock them
+        - silent bypasses are forbidden
+        - if creds block tests, that is a BLOCKER — not a deferral
+
+    - slug: has-preserved-test-intentions
+      say: |
+        double-check: did you preserve test intentions?
+
+        for every test you touched:
+        - what did this test verify before?
+        - does it still verify the same behavior after?
+        - did you change what the test asserts, or fix why it failed?
+
+        forbidden:
+        - weaken assertions to make tests pass
+        - remove test cases that "no longer apply"
+        - change expected values to match broken output
+        - delete tests that fail instead of fix code
+
+        the test knew a truth. if it failed, either:
+        - the code is wrong — fix the code
+        - the test has a bug — fix the bug, keep the intention
+        - requirements changed — document why, get approval
+
+        to "fix tests" via changed intent is not a fix — it is at worst
+        malicious deception, at best reckless negligence. unacceptable.
+
+    - slug: has-journey-tests-from-repros
+      say: |
+        double-check: did you implement each journey sketched in repros?
+
+        look back at the repros artifact:
+        - .behavior/v2026_05_08.gen-logs-env/3.2.distill.repros.experience.*.md
+
+        for each journey test sketch in repros:
+        - is there a test file for it?
+        - does the test follow the BDD given/when/then structure?
+        - does each `when([tN])` step exist?
+
+        **if any journey was planned but not implemented, go back and add it NOW.**
+
+        this is buttonup. absent journey tests = incomplete implementation.
+        test coverage proves prod coverage. no test = no proof = not done.
+
+    - slug: has-contract-output-variants-snapped
+      say: |
+        double-check: does each public contract have EXHAUSTIVE snapshots?
+
+        **zero gaps in caller experience.** every contract must snap every output variant.
+
+        for each new or modified public contract:
+
+        | contract type | what to snap | required variants |
+        |---------------|--------------|-------------------|
+        | cli command | stdout + stderr | success, error, --help, edge cases |
+        | api endpoint | response body | 2xx, 4xx, 5xx, edge cases |
+        | sdk method | return value | success, error, edge cases |
+
+        checklist per contract:
+        - [ ] positive path (success) is snapped
+        - [ ] negative path (error) is snapped
+        - [ ] help/usage is snapped (for cli)
+        - [ ] edge cases are snapped (empty, invalid, boundary)
+        - [ ] snapshot shows actual output, not placeholder
+
+        why this matters:
+        - snapshots enable vibecheck in prs — reviewers see actual output without execute
+        - snapshots detect drift over time — output changes surface in diffs
+        - absent variants mean blind spots in review
+        - exhaustive coverage proves the contract works for all callers
+
+        **zero leniency.** if a contract lacks any variant, add the test case NOW.
+
+        if you find yourself about to say "this variant isn't worth a snapshot" — stop.
+        that is the variant that will break in prod. snap it.
+
+        this is buttonup. absent snapshots = absent proof. add them or fail this gate.
+
+    - slug: has-snap-changes-rationalized
+      say: |
+        double-check: is every `.snap` file change intentional and justified?
+
+        for each `.snap` file in git diff:
+        1. what changed? (added, modified, deleted)
+        2. was this change intended or accidental?
+        3. if intended: what is the rationale?
+        4. if accidental: revert it or explain why the new output is an improvement
+
+        common regressions caught here:
+        - output format degraded (lost alignment, lost structure)
+        - error messages became less helpful
+        - timestamps or ids leaked into snapshots (flaky)
+        - extra output added unintentionally
+
+        forbidden:
+        - "updated snapshots" without per-file rationale
+        - bulk snapshot updates without review
+        - regressions accepted without justification
+
+        every snap change tells a story. make sure the story is intentional.
+
+    - slug: has-critical-paths-frictionless
+      say: |
+        double-check: are the critical paths frictionless in practice?
+
+        look back at the repros artifact for critical paths:
+        - .behavior/v2026_05_08.gen-logs-env/3.2.distill.repros.experience.*.md
+
+        for each critical path:
+        - run through it manually — is it smooth?
+        - are there unexpected errors?
+        - does it feel effortless to the user?
+
+        critical paths must "just work." if there's friction, fix it now.
+
+    - slug: has-ergonomics-validated
+      say: |
+        double-check: does the actual input/output match what felt right at repros?
+
+        compare the implemented input/output to what was sketched in repros:
+        - does the actual input match the planned input?
+        - does the actual output match the planned output?
+        - did the design change between repros and implementation?
+
+        if the ergonomics drifted, either:
+        - update repros to reflect the better design, or
+        - fix the implementation to match the planned ergonomics
+
+    - slug: has-play-test-convention
+      say: |
+        double-check: are journey test files named correctly?
+
+        journey tests should use `.play.test.ts` suffix:
+        - `feature.play.test.ts` — journey test
+        - `feature.play.integration.test.ts` — if repo requires integration runner
+        - `feature.play.acceptance.test.ts` — if repo requires acceptance runner
+
+        verify:
+        - are journey tests in the right location?
+        - do they have the `.play.` suffix?
+        - if not supported, is the fallback convention used?
+
+    - slug: has-fixed-all-gaps
+      say: |
+        final buttonup check: did you FIX every gap you found, or just detect it?
+
+        **this is the buttonup phase. detection is not enough — you must fix.**
+
+        look back at all the reviews above. for every gap you identified:
+        - absent test coverage → did you WRITE the test?
+        - absent prod coverage → did you IMPLEMENT the behavior?
+        - failed test → did you FIX the code or test?
+        - skipped test → did you REMOVE the skip and make it pass?
+
+        **zero omissions.** if any review above surfaced a gap, that gap must be fixed before you pass this gate.
+
+        ask yourself:
+        - did i just note the gap, or did i actually fix it?
+        - is there any item marked "todo" or "later"? (forbidden)
+        - is there any coverage marked incomplete? (forbidden)
+
+        **if you detected it, you fixed it.** prove it with citations.
+
+        this is the final self-review. you are about to hand off to peer review.
+        prove that all items above were addressed — not deferred.
+
+  peer:
+    # slug = ergo-contract-snapshots
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-contract-snapshots.md'
+
+    # slug = mech-external-contracts
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.external-contract-integration-tests.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.remote-boundaries.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.mech-external-contracts.md'
+
+    # --- ergonomist reviews ---
+    # lineage: $rhachet enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p "review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage. emit BLOCKERS and NITPICKS."
+    # slug = ergo-acceptance-journey-coverage
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-acceptance-journey-coverage.md'
+
+    # lineage: $rhachet enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p "review the diff for experiential and visual blemishes in snapshotted acceptance test journeys. emit BLOCKERS and NITPICKS."
+    # slug = ergo-snapshot-visual-blemishes
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-snapshot-visual-blemishes.md'
+
+    # slug = mech-given-when-then
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/rule.require.given-when-then.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/criteria.given_when_then.[seed].v3.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/lessons.howto/*.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.mech-given-when-then.md'
+
+    # --- test intent reviews ---
+    # lineage: $rhachet enroll claude --model sonnet --roles behaver,architect,mechanic -p "review the current implementation for test intent violation diffs. if any of the diffs related to tests loosened assertions or changed the criteria, this is a blocker. tests were added for a reason. we have to maintain the behavior they locked in. emit BLOCKERS and NITPICKS."
+    # slug = mech-test-intent
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.forbid.test-intent-violations.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/work.flow/refactor/rule.require.review-test-changes.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.mech-test-intent.md'
+
+    # verify test scope purity (grain, boundaries, mocks, blackbox)
+    - $rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/rule.require.test-coverage-by-grain.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.unit.remote-boundaries.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.integration/rule.forbid.integration.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.forbid.acceptance.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.require.acceptance.blackbox.md' --diffs since-main --paths-with '{src,blackbox}/**/*.test.ts' --join intersect --output '$route/.reviews/$stone.peer-review.test-scope-purity.md' --mode hard
+
+judges:
+  # enforce peer reviews pass with zero blockers
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0

--- a/.behavior/v2026_05_08.gen-logs-env/5.3.verification.stone
+++ b/.behavior/v2026_05_08.gen-logs-env/5.3.verification.stone
@@ -1,0 +1,304 @@
+prove the deliverable works via test verification — fix all gaps
+
+---
+
+## .what
+
+this is the verification gate — the **buttonup phase**.
+
+you cannot pass execution without proof that all tests pass. more importantly: **test coverage enforces prod coverage**. if tests are absent, prod is incomplete. if prod is incomplete, fix it.
+
+## .the buttonup mandate: zero omissions
+
+**this is not a detection phase. this is a completion phase.**
+
+when you find a gap, you do not note it and move on. you **fix it**.
+
+| gap type | action |
+|----------|--------|
+| absent test coverage | write the test NOW |
+| absent prod coverage | implement the behavior NOW |
+| failed test | fix the code or fix the test NOW |
+| skipped test | remove the skip and make it pass NOW |
+
+**if you detect it, you fix it. no exceptions.**
+
+## .strictness: zero tolerance, zero exceptions
+
+**this gate enforces absolute standards. there is no leniency.**
+
+| constraint | definition |
+|------------|------------|
+| zero deferrals | you cannot defer any test to later. all tests pass now or you fail. |
+| zero fake tests | tests must verify real behavior. assertions that always pass are fraud. |
+| zero unproven claims | every claim of "test passes" must cite the exact command run and output. |
+| zero credential excuses | "i don't have creds" is not an excuse. get them, mock them, or fail. |
+| zero skips | .skip() and .only() are forbidden. silent bypasses are forbidden. |
+| zero exceptions | there are no special cases. the rules apply to all. |
+| zero omissions | if you find a gap in coverage, you fix it — test or prod. |
+
+**if a blocker prevents tests from run, that is a BLOCKER. full stop.**
+
+you do not proceed. you do not defer. you fix it or you fail the gate.
+
+## .why
+
+**why does this gate exist?**
+
+your crew is about to review a pr you wrote. they need proof it works — not words, proof. tests are that proof.
+
+**test coverage drives prod coverage.** if a behavior lacks a test, that behavior is unproven. unproven behaviors are incomplete deliverables. the test proves the implementation exists and works.
+
+without this gate:
+- tests might fail and nobody notices
+- tests might be skipped and nobody notices
+- behaviors might lack coverage and nobody notices
+- broken code ships to peers
+- incomplete implementations slip through
+
+with this gate:
+- every test passes or you fix it
+- every behavior has coverage or you add it
+- every skip is removed or justified
+- proven code ships to peers
+- **gaps get fixed, not deferred**
+
+**the cardinal rules**:
+1. never leave behavior without true, dependable test coverage
+2. never offload work onto your crew unless there is truly, fundamentally no other option
+3. never claim a test passes without cite of the exact command and output
+
+you fix it yourself. you exhaust every option: debug, research, try alternatives. only when you hit a wall that is physically impossible to climb alone — credentials only the foreman possesses, access only they can grant — only then may you ask for help.
+
+## .how
+
+reference the below for full context
+- .behavior/v2026_05_08.gen-logs-env/0.wish.md
+- .behavior/v2026_05_08.gen-logs-env/1.vision.md
+- .behavior/v2026_05_08.gen-logs-env/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_05_08.gen-logs-env/3.2.distill.repros.experience.*.md (if declared) ← **repros artifact**
+
+---
+
+### step 1: emit verification checklist
+
+emit to
+- .behavior/v2026_05_08.gen-logs-env/5.3.verification.yield.md
+
+this is your roadmap. emit it first, then work through it step by step.
+
+**checklist structure:**
+
+```
+## verification checklist
+
+### behavior coverage (with reference to repros)
+
+for each journey sketched in repros, verify it was implemented with snapshots.
+
+| journey (from repros) | test file | snapshots? | critical path? | ergonomics ok? | status |
+|-----------------------|-----------|------------|----------------|----------------|--------|
+| {journey 1}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+| {journey 2}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+...
+
+### zero skips verified
+- [ ] no .skip() or .only() found
+- [ ] no silent credential bypasses
+- [ ] no prior failures carried forward
+
+### snapshot coverage for contract outputs
+
+each public contract needs dedicated snapshots that demonstrate its stdout for:
+- **vibechecks in prs** — reviewers see actual output without executing code
+- **drift detection** — changes to output surface in diffs over time
+
+| contract | output variants | snapshot file | status |
+|----------|-----------------|---------------|--------|
+| {command 1} | success, error, help | {path.snap} | ⏳ |
+| {command 2} | success, error, help | {path.snap} | ⏳ |
+...
+
+checklist:
+- [ ] every new cli command has `.snap` snapshots for stdout/stderr
+- [ ] every new app screen has `.snap` snapshots for screenshots
+- [ ] every new sdk method has `.snap` snapshots for responses
+- [ ] each output variant is exercised (success, error, edge cases)
+- [ ] snapshots demonstrate actual output, not just "it ran"
+
+### snapshot change rationalization
+
+for each `.snap` file changed, rationalize whether the change was intended or accidental:
+
+| snap file | change type | intended? | rationale |
+|-----------|-------------|-----------|-----------|
+| {path.snap} | added / modified / deleted | yes / no | {why this change is correct} |
+...
+
+checklist:
+- [ ] every `.snap` change has been reviewed
+- [ ] intended changes have clear rationale
+- [ ] accidental changes have been reverted or justified as improvements
+
+### tests executed — with proof
+
+**every test run must be proven with exact command and output.**
+
+| test suite | command run | result | proof (exit code + summary) |
+|------------|-------------|--------|----------------------------|
+| types | `npm run test:types` | ✓ / ✗ | exit 0, no errors |
+| lint | `npm run test:lint` | ✓ / ✗ | exit 0, no errors |
+| format | `npm run test:format` | ✓ / ✗ | exit 0, no errors |
+| unit | `npm run test:unit` | ✓ / ✗ | exit 0, N tests passed |
+| integration | `npm run test:integration` | ✓ / ✗ | exit 0, N tests passed |
+| acceptance | `npm run test:acceptance` | ✓ / ✗ | exit 0, N tests passed |
+
+checklist:
+- [ ] every test command was run (not "i think it passed")
+- [ ] every test command output was observed (not assumed)
+- [ ] the exact exit code was verified (0 = pass, non-zero = fail)
+- [ ] no tests were skipped, mocked, or faked
+
+**zero unproven claims.** if you claim a test passes, cite the command and output.
+
+### contract output snapshot exhaustiveness
+
+**every user-faced contract must have exhaustive snapshot coverage.**
+
+| contract type | contract | positive path snapped? | negative path snapped? | edge cases snapped? |
+|---------------|----------|------------------------|------------------------|---------------------|
+| cli | {command} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| api | {endpoint} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| sdk | {method} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+
+checklist:
+- [ ] every cli command has stdout/stderr snapshots for success, error, and help
+- [ ] every api endpoint has response snapshots for success and error codes
+- [ ] every sdk method has return value snapshots for success and error
+- [ ] every contract has edge case snapshots (empty input, invalid input, boundary)
+
+**zero gaps in caller experience.** the reviewer must see exactly what callers see.
+
+### blockers
+- none (or list handoff references)
+```
+
+update the checklist as you complete each step below.
+
+---
+
+### step 2: verify AND FIX behavior coverage
+
+walk through wish and vision:
+- every behavior promised must have an acceptance test
+- for each behavior, you can point to the test file
+- no behavior left untested
+
+**why?** your crew trusts the test suite. if a behavior isn't tested, it isn't proven. untested behaviors are unverified promises.
+
+**test coverage enforces prod coverage.** if a test is absent, either:
+1. the behavior was not implemented → IMPLEMENT IT NOW
+2. the behavior was implemented without a test → WRITE THE TEST NOW
+
+if a behavior lacks a test, **write one NOW**. do not move on with gaps. update your checklist when done.
+
+---
+
+### step 3: verify AND FIX zero skips
+
+scan for forbidden patterns:
+- `.skip()` or `.only()` in test files
+- `if (!credentials) return` or similar silent bypasses
+- prior failures carried forward (known-broken tests)
+
+**why?** failures are better than skips. skips hide problems. failures expose them. a skipped test is a lie — it pretends coverage exists when it doesn't.
+
+**this is buttonup.** if you find skips:
+1. REMOVE the skip
+2. MAKE the test pass (fix the code or fix the test)
+3. update your checklist
+
+do not note skips and move on. fix them. all tests must run.
+
+---
+
+### step 4: run all tests AND FIX all failures
+
+run each test suite and **cite the exact command and output**.
+
+```bash
+npm run test:types      # cite exit code
+npm run test:lint       # cite exit code
+npm run test:format     # cite exit code
+npm run test:unit       # cite exit code + test count
+npm run test:integration # cite exit code + test count
+npm run test:acceptance  # cite exit code + test count
+```
+
+all must pass — no exceptions. no deferrals. no "i'll fix it later."
+
+**this is buttonup.** if tests fail, fix them. that is the job.
+
+failures indicate one of:
+1. prod code is broken → FIX THE PROD CODE
+2. test has a bug → FIX THE TEST BUG (preserve intention)
+3. coverage gap exists → FILL THE GAP
+
+**consider all failures as defects from this pr.** there are no "prior failures."
+
+if a test was broken before you started — fix it. if a test is flaky — fix it. if a test fails for reasons unrelated to your changes — fix it anyway. you do not get to say "that was already broken." you are here now. you fix it.
+
+**take initiative. take ownership.**
+
+**preserve test intentions.** when you fix a test, you fix why it failed — not what it tests. to change what a test verifies is not a fix. it is at worst malicious deception, at best reckless negligence. the test knew a truth. if it fails, either the code is wrong or the test has a bug. fix the cause, not the assertion.
+
+**zero fake tests.** a test that always passes is fraud. a test that skips is a lie. a test that mocks the system under test proves nothingness. tests must verify real behavior against real code.
+
+**escalation path:**
+1. debug the failure — read the error, understand the cause
+2. research — search for similar issues, read docs
+3. try alternatives — different approach, different tool
+4. ask for help — other resources, other clones
+5. deeper research — exhaust every option
+6. only if insurmountable — emit handoff (see step 5)
+
+**ask yourself at each level:**
+- did i read the error message carefully?
+- did i search for similar issues?
+- did i try a different approach?
+- did i isolate the problem?
+- did i ask for help?
+- did i exhaust every option?
+
+you move to handoff only when you can answer "yes" to all of the above and still cannot proceed.
+
+update your checklist when all tests pass.
+
+---
+
+### step 5: handoff (only if insurmountable)
+
+a handoff is a document that transfers work to your foreman because you hit a wall that is physically impossible to climb alone.
+
+**foreman-only blockers:**
+- credentials only the foreman possesses
+- external access only the foreman can grant
+- approval that requires foreman authority
+
+handoff is the absolute last resort. you must exhaust every option before you consider it.
+
+if you need to emit a handoff:
+
+emit to
+- .behavior/v2026_05_08.gen-logs-env/5.3.verification.handoff.v$N.to_foreman.md
+
+**handoff must include:**
+1. what you tried (list every approach you attempted)
+2. why each approach failed (be specific)
+3. what makes this fundamentally impossible without foreman intervention
+4. is this truly a "foreman possesses the key" situation?
+5. rewind instruction: `rhx route.stone.set --stone 5.3.verification --as rewound`
+
+your crew should read your handoff and think: "yes, there was truly no other way."
+
+update your checklist to reference the handoff.

--- a/.behavior/v2026_05_08.gen-logs-env/5.3.verification.yield.md
+++ b/.behavior/v2026_05_08.gen-logs-env/5.3.verification.yield.md
@@ -1,0 +1,55 @@
+# verification checklist
+
+## behavior coverage
+
+| behavior | test file | type | status |
+|----------|-----------|------|--------|
+| genLogMethods accepts env parameter | genLogMethods.test.ts | unit | ✓ |
+| genLogMethods exposes env on LogMethods | genLogMethods.test.ts | unit | ✓ |
+| genContextLogTrail accepts env | genContextLogTrail.test.ts | unit | ✓ |
+| genContextLogTrail uses level: { minimum } | genContextLogTrail.test.ts | unit | ✓ |
+| withLogTrail inherits env from context.log | withLogTrail.test.ts | unit | ✓ |
+| outlets receive env in LogEvent | generateLogMethod.test.ts | unit | ✓ |
+
+## zero skips verified
+
+- [x] no `.skip()` or `.only()` found (grep returned 0 matches)
+- [x] no silent credential bypasses
+- [x] no prior failures carried forward
+
+## snapshot coverage
+
+no new contracts added. extant snapshots unchanged.
+
+| snap file | change type | rationale |
+|-----------|-------------|-----------|
+| (none) | no changes | env feature is internal wiring, no new output format |
+
+## tests executed — with proof
+
+| test suite | command run | result | proof |
+|------------|-------------|--------|-------|
+| types | `rhx git.repo.test --what types` | ✓ | exit 0, passed (1s) |
+| format | `rhx git.repo.test --what format` | ✓ | exit 0, passed (1s) |
+| lint | `rhx git.repo.test --what lint` | ✓ | exit 0, passed (3s) |
+| unit | `rhx git.repo.test --what unit --mode apply` | ✓ | 55 passed, 0 failed, 0 skipped |
+| integration | `rhx git.repo.test --what integration --mode apply` | ✓ | 9 passed, 0 failed, 0 skipped |
+| acceptance | `rhx git.repo.test --what acceptance --mode apply` | ✓ | 5 passed, 0 failed, 0 skipped |
+
+## contract output snapshot exhaustiveness
+
+this feature adds internal API parameters (env to genLogMethods). no new CLI commands, API endpoints, or SDK methods were added.
+
+| contract type | applicable | status |
+|---------------|------------|--------|
+| cli | no new commands | n/a |
+| api | no new endpoints | n/a |
+| sdk | genLogMethods signature change | ✓ covered by unit tests |
+
+## blockers
+
+- none
+
+## summary
+
+all tests pass. all behaviors covered. no skips. no blockers.

--- a/.behavior/v2026_05_08.gen-logs-env/refs/template.[feedback].v1.[given].by_human.md
+++ b/.behavior/v2026_05_08.gen-logs-env/refs/template.[feedback].v1.[given].by_human.md
@@ -1,0 +1,27 @@
+emit your response to the feedback into
+- .behavior/v2026_05_08.gen-logs-env/$BEHAVIOR_REF_NAME.[feedback].v$FEEDBACK_VERSION.[taken].by_robot.md
+
+1. emit your response checklist
+2. exec your response plan
+3. emit your response checkoffs into the checklist
+
+---
+
+first, bootup your mechanics briefs again
+
+./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic
+
+---
+---
+---
+
+
+# blocker.1
+
+---
+
+# nitpick.2
+
+---
+
+# blocker.3

--- a/.behavior/v2026_05_08.gen-logs-env/review/self/.gitignore
+++ b/.behavior/v2026_05_08.gen-logs-env/review/self/.gitignore
@@ -1,0 +1,3 @@
+# ignore all self-review files
+*
+!.gitignore

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "domain-objects": "0.31.10",
     "helpful-errors": "1.7.3",
     "iso-time": "^1.11.5",
+    "sdk-environment": "0.1.3",
     "type-fns": "1.21.2"
   },
   "devDependencies": {
@@ -84,12 +85,12 @@
     "esbuild-register": "3.6.0",
     "husky": "8.0.3",
     "jest": "30.2.0",
-    "rhachet": "1.41.7",
+    "rhachet": "1.41.11",
     "rhachet-brains-anthropic": "^0.4.1",
     "rhachet-brains-xai": "^0.3.3",
     "rhachet-roles-bhrain": "0.27.6",
-    "rhachet-roles-bhuild": "0.21.7",
-    "rhachet-roles-ehmpathy": "1.35.5",
+    "rhachet-roles-bhuild": "0.21.9",
+    "rhachet-roles-ehmpathy": "1.35.6",
     "rhachet-roles-rhachet": "^0.1.7",
     "test-fns": "1.4.2",
     "tsc-alias": "1.8.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       iso-time:
         specifier: ^1.11.5
         version: 1.11.5
+      sdk-environment:
+        specifier: 0.1.3
+        version: 0.1.3
       type-fns:
         specifier: 1.21.2
         version: 1.21.2
@@ -65,13 +68,13 @@ importers:
         version: 0.13.18
       declapract-typescript-ehmpathy:
         specifier: ^0.47.14
-        version: 0.47.14(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(declapract@0.13.18)(esbuild@0.25.12)(zod@4.3.4)
+        version: 0.47.14(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(declapract@0.13.18)(esbuild@0.25.12)(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       declastruct:
         specifier: 1.7.3
         version: 1.7.3(domain-objects@0.31.10)
       declastruct-github:
         specifier: 1.3.0
-        version: 1.3.0(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+        version: 1.3.0(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       depcheck:
         specifier: 1.4.3
         version: 1.4.3
@@ -85,26 +88,26 @@ importers:
         specifier: 30.2.0
         version: 30.2.0(@types/node@22.15.21)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@22.15.21)(typescript@5.4.5))
       rhachet:
-        specifier: 1.41.7
-        version: 1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+        specifier: 1.41.11
+        version: 1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
       rhachet-brains-anthropic:
         specifier: ^0.4.1
-        version: 0.4.1(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+        version: 0.4.1(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       rhachet-brains-xai:
         specifier: ^0.3.3
-        version: 0.3.3(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+        version: 0.3.3(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       rhachet-roles-bhrain:
         specifier: 0.27.6
-        version: 0.27.6(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))
+        version: 0.27.6(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))
       rhachet-roles-bhuild:
-        specifier: 0.21.7
-        version: 0.21.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-roles-bhrain@0.27.6(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))))
+        specifier: 0.21.9
+        version: 0.21.9(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-roles-bhrain@0.27.6(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))))(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       rhachet-roles-ehmpathy:
-        specifier: 1.35.5
-        version: 1.35.5(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+        specifier: 1.35.6
+        version: 1.35.6(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       rhachet-roles-rhachet:
         specifier: ^0.1.7
-        version: 0.1.7(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+        version: 0.1.7(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       test-fns:
         specifier: 1.4.2
         version: 1.4.2
@@ -168,8 +171,16 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
+  '@aws-sdk/client-account@3.1042.0':
+    resolution: {integrity: sha512-T3+UOMMPR3HIPBnHb0gv0Ct0Ji3xa/7nK6fpf4boath1PpWeRA/yYofZQzfwWflA/on7+yKa2r9Y5Vv/6jUEmA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-cloudwatch-logs@3.1040.0':
     resolution: {integrity: sha512-k63S7YYKRXziQwF5CMrUK3W/ffY+rUA/WJNYoYAqqDJnMM39P2AEPPQ3DjuvZwqdc92OSam9TuRwmMW/Fg0l3g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-iam@3.1042.0':
+    resolution: {integrity: sha512-Toh0WvCMY0umn2S+WEvrHqOYD6+f4N2wHcClpbQ4ZtJZ0id0m41ny2fIhA/7X3P0KMrETlGz7/gPU5+HAUwJvg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-s3@3.946.0':
@@ -204,12 +215,20 @@ packages:
     resolution: {integrity: sha512-bJV7eViSJV6GSuuN+VIdNVPdwPsNSf75BiC2v5alPrjR/OCcqgKwSZInKbDFz9mNeizldsyf67jt6YSIiv53Cw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.34':
+    resolution: {integrity: sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.946.0':
     resolution: {integrity: sha512-/zeOJ6E7dGZQ/l2k7KytEoPJX0APIhwt0A79hPf/bUpMF4dDs2P6JmchDrotk0a0Y/MIdNF8sBQ/MEOPnBiYoQ==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.35':
     resolution: {integrity: sha512-x/BQGEIdq0oI+4WxLjKmnQvT7CnF9r8ezdGt7wXwxb7ckHXQz0Zmgxt8v3Ne0JaT3R5YefmuybHX6E8EnsDXyA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.36':
+    resolution: {integrity: sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.946.0':
@@ -220,12 +239,20 @@ packages:
     resolution: {integrity: sha512-eUTpmWfd/BKsq9medhCRcu+GRAhFP2Zrn7/2jKDHHOOjCkhrMoTp/t4cEthqFoG7gE0VGp5wUxrXTdvBCmSmJg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.38':
+    resolution: {integrity: sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.946.0':
     resolution: {integrity: sha512-5iqLNc15u2Zx+7jOdQkIbP62N7n2031tw5hkmIG0DLnozhnk64osOh2CliiOE9x3c4P9Pf4frAwgyy9GzNTk2g==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.37':
     resolution: {integrity: sha512-Ty68y8ISSC+g5Q3D0K8uAaoINwvfaOslnNpsF/LgVUxyosYXHawcK2yV4HLXDVugiTTYLQfJfcw0ce5meAGkKw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.38':
+    resolution: {integrity: sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.946.0':
@@ -236,12 +263,20 @@ packages:
     resolution: {integrity: sha512-BQ9XYnBDVxR2HuV5huXYQYF/PZMTsY+EnwfGnCU2cA8Zw63XpkOtPY8WqiMIZMQCrKPQQEiFURS/o9CIolRLqg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.39':
+    resolution: {integrity: sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.946.0':
     resolution: {integrity: sha512-GtGHX7OGqIeVQ3DlVm5RRF43Qmf3S1+PLJv9svrdvAhAdy2bUb044FdXXqrtSsIfpzTKlHgQUiRo5MWLd35Ntw==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.33':
     resolution: {integrity: sha512-yfjGksI9WQbdMObb0VeLXqzTLI+a0qXLJT9gCDiv0+X/xjPpI3mTz6a5FibrhpuEKIe0gSgvs3MaoFZy5cx4WA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.34':
+    resolution: {integrity: sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.946.0':
@@ -252,12 +287,20 @@ packages:
     resolution: {integrity: sha512-fpwE+20ntpp3i9Xb9vUuQfXLDKYHH+5I2V+ZG96SX1nBzrruhy10RXDgmN7t1etOz3c55stlA3TeQASUA451NQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.38':
+    resolution: {integrity: sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.946.0':
     resolution: {integrity: sha512-ocBCvjWfkbjxElBI1QUxOnHldsNhoU0uOICFvuRDAZAoxvypJHN3m5BJkqb7gqorBbcv3LRgmBdEnWXOAvq+7Q==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.37':
     resolution: {integrity: sha512-aryawqyebf+3WhAFNHfF62rekFpYtVcVN7dQ89qnAWsa4n5hJst8qBG6gXC24WHtW7Nnhkf9ScYnjwo0Brn3bw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.38':
+    resolution: {integrity: sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-bucket-endpoint@3.936.0':
@@ -308,6 +351,10 @@ packages:
     resolution: {integrity: sha512-YhPix+0x/MdQrb1Ug1GDKeS5fqylIy+naz800asX8II4jqfTk2KY2KhmmYCwZcky8YWtRQQwWCGdoqeAnip8Uw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-sdk-s3@3.972.37':
+    resolution: {integrity: sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-ssec@3.936.0':
     resolution: {integrity: sha512-/GLC9lZdVp05ozRik5KsuODR/N7j+W+2TbfdFL3iS+7un+gnP6hC8RDOZd6WhpZp7drXQ9guKiTAxkZQwzS8DA==}
     engines: {node: '>=18.0.0'}
@@ -332,6 +379,10 @@ packages:
     resolution: {integrity: sha512-jGFr6DxtcMTmzOkG/a0jCZYv4BBDmeNYVeO+/memSoDkYCJu4Y58xviYmzwJfYyIVSts+X/BVjJm1uGBnwHEMg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.6':
+    resolution: {integrity: sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/region-config-resolver@3.936.0':
     resolution: {integrity: sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==}
     engines: {node: '>=18.0.0'}
@@ -348,8 +399,16 @@ packages:
     resolution: {integrity: sha512-amP7tLikppN940wbBFISYqiuzVmpzMS9U3mcgtmVLjX4fdWI/SNCvrXv6ZxfVzTT4cT0rPKOLhFah2xLwzREWw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.25':
+    resolution: {integrity: sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1039.0':
     resolution: {integrity: sha512-NMSFL2HwkAOoCeLCQiqoOq5pT3vVbSjww2QZTuYgYknVwhhv125PSDzZIcL5EYnlxuPWjEOdauZK+FspkZDVdw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1041.0':
+    resolution: {integrity: sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.946.0':
@@ -1759,6 +1818,10 @@ packages:
     resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.24.0':
+    resolution: {integrity: sha512-rZ5YfycIXX6puoGjthnDiMpUgtKNOq3c7CndQYkCNYQTv26AiCrZQOJPy7ANSfZ6Okk3UvCRnmO1OYWlLnYZgg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.2.14':
     resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
     engines: {node: '>=18.0.0'}
@@ -1953,6 +2016,10 @@ packages:
 
   '@smithy/util-waiter@4.2.5':
     resolution: {integrity: sha512-Dbun99A3InifQdIrsXZ+QLcC0PGBPAdrl4cj1mTgJvyc9N2zf7QSxg8TBkzsCmGJdE3TLbO9ycwpY0EkWahQ/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-waiter@4.4.0':
+    resolution: {integrity: sha512-7kAlrB3n7/BHyw+uLq83d5jdadPUcDkdMOUSGxvpXjrJ++G0hTedTnoNChjybIxhZ/Gk7sCrfIOLkMAB0LhRBA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/uuid@1.1.2':
@@ -4367,15 +4434,15 @@ packages:
     peerDependencies:
       rhachet-brains-xai: '>=0.3.0'
 
-  rhachet-roles-bhuild@0.21.7:
-    resolution: {integrity: sha512-IqyHilL+n30P0XU0nx8PfxH1M5DQQxjKoUHpATKYt29uGurW9iCvoIxaOZdI0JvRUs2MuRW8cSk+LYe+enVz+A==}
+  rhachet-roles-bhuild@0.21.9:
+    resolution: {integrity: sha512-wKMfrrb7gctukIJSTD60KQapL8UYTFtcQu0aTF8x8qudr3TtFXt358lmpBmYkjslhZnwPoWWZjWBh8k/yiEdlg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       rhachet-brains-xai: '>=0.3.3'
       rhachet-roles-bhrain: '>=0.12.1'
 
-  rhachet-roles-ehmpathy@1.35.5:
-    resolution: {integrity: sha512-1u1xSYz4LbDnrlt+vv/H4YRrSvuqSQZQgMT9HBFmxNbq0R6ERWubuoodlyEflyFDPxBQp9lfUI5lrnr3EtOMSw==}
+  rhachet-roles-ehmpathy@1.35.6:
+    resolution: {integrity: sha512-sdF09g+jBiFE9Zm+4cO+9ON6HXyyIPCRv9di34hybR1Wzu7GBZxK2oaiucv17J7CRS4Pe0aVUMOS9M0VJJGEKQ==}
     engines: {node: '>=8.0.0'}
 
   rhachet-roles-rhachet@0.1.7:
@@ -4384,8 +4451,8 @@ packages:
     peerDependencies:
       rhachet: '>=1.0.0'
 
-  rhachet@1.41.7:
-    resolution: {integrity: sha512-RQ5ZT4S0o+g0kR8vT6grvDNu+Oy2zBmnJSsF+mx7VRre2FfDZg2AHQtPhzD9UDJPJuT6EB6g2Y8BVE3LH/k7Pg==}
+  rhachet@1.41.11:
+    resolution: {integrity: sha512-qkfYevUqIbIJONE0w9MsquVSUj7Exof56igQ5MA2Gm0sscQFml/thi64ADMRCwLgRzrb22Brqe+d5wU8usp7aA==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
@@ -4426,6 +4493,10 @@ packages:
   scss-parser@1.0.6:
     resolution: {integrity: sha512-SH3TaoaJFzfAtqs3eG1j5IuHJkeEW5rKUPIjIN+ZorLAyJLHItQGnsgwHk76v25GtLtpT9IqfAcqK4vFWdiw+w==}
     engines: {node: '>=6.0.0'}
+
+  sdk-environment@0.1.3:
+    resolution: {integrity: sha512-MSDFIxWcJFP9dVWkniTmBUwpv9Y8/zU+abid2qscffHkSUgO1pbf2o+sxWaCEDd73pXvBFDyYtez+tvU+xso/g==}
+    engines: {node: '>=8.0.0'}
 
   seedrandom@3.0.5:
     resolution: {integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==}
@@ -4802,6 +4873,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -5033,6 +5105,50 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
+  '@aws-sdk/client-account@3.1042.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/client-cloudwatch-logs@3.1040.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -5076,6 +5192,51 @@ snapshots:
       '@smithy/util-middleware': 4.2.14
       '@smithy/util-retry': 4.3.6
       '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-iam@3.1042.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/util-waiter': 4.4.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -5292,6 +5453,14 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.34':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.946.0':
     dependencies:
       '@aws-sdk/core': 3.946.0
@@ -5308,6 +5477,19 @@ snapshots:
   '@aws-sdk/credential-provider-http@3.972.35':
     dependencies:
       '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.36':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
       '@aws-sdk/types': 3.973.8
       '@smithy/fetch-http-handler': 5.3.17
       '@smithy/node-http-handler': 4.6.1
@@ -5356,6 +5538,25 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-login': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-login@3.946.0':
     dependencies:
       '@aws-sdk/core': 3.946.0
@@ -5373,6 +5574,19 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.7
       '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/protocol-http': 5.3.14
@@ -5416,6 +5630,23 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.972.39':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-ini': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-process@3.946.0':
     dependencies:
       '@aws-sdk/core': 3.946.0
@@ -5428,6 +5659,15 @@ snapshots:
   '@aws-sdk/credential-provider-process@3.972.33':
     dependencies:
       '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.34':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
@@ -5460,6 +5700,19 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-sso@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/token-providers': 3.1041.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-web-identity@3.946.0':
     dependencies:
       '@aws-sdk/core': 3.946.0
@@ -5476,6 +5729,18 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.7
       '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
@@ -5585,6 +5850,23 @@ snapshots:
   '@aws-sdk/middleware-sdk-s3@3.972.36':
     dependencies:
       '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
       '@aws-sdk/types': 3.973.8
       '@aws-sdk/util-arn-parser': 3.972.3
       '@smithy/core': 3.23.17
@@ -5724,6 +6006,50 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/nested-clients@3.997.6':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.25
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/region-config-resolver@3.936.0':
     dependencies:
       '@aws-sdk/types': 3.936.0
@@ -5758,10 +6084,31 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.25':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.37
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1039.0':
     dependencies:
       '@aws-sdk/core': 3.974.7
       '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/token-providers@3.1041.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
@@ -7273,6 +7620,12 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
+  '@smithy/core@3.24.0':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.14':
     dependencies:
       '@smithy/node-config-provider': 4.3.14
@@ -7574,6 +7927,11 @@ snapshots:
     dependencies:
       '@smithy/abort-controller': 4.2.5
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-waiter@4.4.0':
+    dependencies:
+      '@smithy/core': 3.24.0
       tslib: 2.8.1
 
   '@smithy/uuid@1.1.2':
@@ -8444,10 +8802,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  declapract-typescript-ehmpathy@0.47.14(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(declapract@0.13.18)(esbuild@0.25.12)(zod@4.3.4):
+  declapract-typescript-ehmpathy@0.47.14(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(declapract@0.13.18)(esbuild@0.25.12)(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
     dependencies:
       declapract: 0.13.18
-      domain-objects: 0.31.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+      domain-objects: 0.31.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       esbuild-register: 3.6.0(esbuild@0.25.12)
       expect: 29.4.2
       flat: 5.0.2
@@ -8459,9 +8817,9 @@ snapshots:
       - '@types/node'
       - aws-crt
       - esbuild
+      - rhachet
       - supports-color
       - ws
-      - zod
 
   declapract@0.13.18:
     dependencies:
@@ -8487,12 +8845,12 @@ snapshots:
       uuid: 9.0.0
       yaml: 1.6.0
 
-  declastruct-github@1.3.0(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4):
+  declastruct-github@1.3.0(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
     dependencies:
       '@ehmpathy/uni-time': 1.7.4
       '@octokit/rest': 21.1.1
       as-procedure: 1.1.1
-      domain-objects: 0.31.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+      domain-objects: 0.31.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       helpful-errors: 1.5.3
       libsodium-wrappers: 0.7.16
       simple-in-memory-cache: 0.4.0
@@ -8504,8 +8862,8 @@ snapshots:
       - '@tensorflow/tfjs'
       - '@types/node'
       - aws-crt
+      - rhachet
       - ws
-      - zod
 
   declastruct@1.7.3(domain-objects@0.31.10):
     dependencies:
@@ -8635,14 +8993,32 @@ snapshots:
       type-fns: 1.21.0
       uuid-fns: 1.1.3
 
+  domain-objects@0.31.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
+    dependencies:
+      change-case: 4.1.2
+      domain-objects: 0.31.3
+      helpful-errors: 1.5.3
+      joi: 17.4.0
+      rhachet: 1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+      rhachet-roles-ehmpathy: 1.35.6(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+      type-fns: 1.21.0
+      uuid-fns: 1.1.3
+    transitivePeerDependencies:
+      - '@huggingface/transformers'
+      - '@tensorflow/tfjs'
+      - '@types/node'
+      - aws-crt
+      - rhachet
+      - ws
+
   domain-objects@0.31.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4):
     dependencies:
       change-case: 4.1.2
       domain-objects: 0.31.3
       helpful-errors: 1.5.3
       joi: 17.4.0
-      rhachet: 1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
-      rhachet-roles-ehmpathy: 1.35.5(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+      rhachet: 1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+      rhachet-roles-ehmpathy: 1.35.6(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       type-fns: 1.21.0
       uuid-fns: 1.1.3
     transitivePeerDependencies:
@@ -10302,7 +10678,7 @@ snapshots:
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
 
-  rhachet-brains-anthropic@0.4.1(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
+  rhachet-brains-anthropic@0.4.1(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
     dependencies:
       '@anthropic-ai/claude-agent-sdk': 0.1.76(zod@4.3.4)
       '@anthropic-ai/sdk': 0.71.2(zod@4.3.4)
@@ -10310,19 +10686,19 @@ snapshots:
       helpful-errors: 1.5.3
       iso-price: 1.1.1(domain-objects@0.31.9)
       iso-time: 1.11.1
-      rhachet: 1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+      rhachet: 1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
       rhachet-artifact: 1.0.1
       rhachet-artifact-git: 1.1.5
       type-fns: 1.21.0
       zod: 4.3.4
 
-  rhachet-brains-xai@0.3.3(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
+  rhachet-brains-xai@0.3.3(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
     dependencies:
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
       iso-price: 1.1.1(domain-objects@0.31.9)
       openai: 5.8.2(zod@4.3.4)
-      rhachet: 1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+      rhachet: 1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
       rhachet-artifact: 1.0.1
       rhachet-artifact-git: 1.1.5
       type-fns: 1.21.0
@@ -10330,7 +10706,7 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
-  rhachet-roles-bhrain@0.27.6(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))):
+  rhachet-roles-bhrain@0.27.6(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))):
     dependencies:
       '@ehmpathy/as-command': 1.0.3
       '@ehmpathy/uni-time': 1.8.1
@@ -10347,7 +10723,7 @@ snapshots:
       openai: 5.8.2(zod@4.3.4)
       rhachet-artifact: 1.0.0
       rhachet-artifact-git: 1.1.0
-      rhachet-brains-xai: 0.3.3(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+      rhachet-brains-xai: 0.3.3(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       serde-fns: 1.2.0
       simple-in-memory-cache: 0.4.0
       type-fns: 1.21.0
@@ -10362,24 +10738,25 @@ snapshots:
       - react-native-b4a
       - ws
 
-  rhachet-roles-bhuild@0.21.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-roles-bhrain@0.27.6(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))):
+  rhachet-roles-bhuild@0.21.9(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-roles-bhrain@0.27.6(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))))(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
     dependencies:
       domain-objects: 0.31.9
       emoji-space-shim: 0.0.0
       helpful-errors: 1.7.3
       iso-time: 1.11.3
-      rhachet-brains-xai: 0.3.3(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
-      rhachet-roles-bhrain: 0.27.6(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))
-      test-fns: 1.15.0(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+      rhachet-brains-xai: 0.3.3(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+      rhachet-roles-bhrain: 0.27.6(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))
+      test-fns: 1.15.0(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       zod: 4.3.4
     transitivePeerDependencies:
       - '@huggingface/transformers'
       - '@tensorflow/tfjs'
       - '@types/node'
       - aws-crt
+      - rhachet
       - ws
 
-  rhachet-roles-ehmpathy@1.35.5(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
+  rhachet-roles-ehmpathy@1.35.6(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
     dependencies:
       '@atjsh/llmlingua-2': 2.0.3(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(js-tiktoken@1.0.21)
       '@ehmpathy/as-command': 1.0.3
@@ -10393,13 +10770,13 @@ snapshots:
       openai: 5.8.2(zod@4.3.4)
       rhachet-artifact: 1.0.0
       rhachet-artifact-git: 1.1.0
-      rhachet-brains-xai: 0.3.3(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
-      rhachet-roles-rhachet: 0.1.7(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+      rhachet-brains-xai: 0.3.3(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+      rhachet-roles-rhachet: 0.1.7(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       serde-fns: 1.2.0
       simple-in-memory-cache: 0.4.0
       simple-on-disk-cache: 1.7.3
       type-fns: 1.21.0
-      with-simple-cache: 0.15.3(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+      with-simple-cache: 0.15.3
       with-simple-caching: 0.14.4
       wrapper-fns: 1.1.7
       zod: 4.3.4
@@ -10411,11 +10788,11 @@ snapshots:
       - rhachet
       - ws
 
-  rhachet-roles-rhachet@0.1.7(rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
+  rhachet-roles-rhachet@0.1.7(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
     dependencies:
-      rhachet: 1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+      rhachet: 1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
 
-  rhachet@1.41.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4):
+  rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4):
     dependencies:
       '@aws-sdk/client-sso': 3.1041.0
       '@noble/curves': 2.0.1
@@ -10494,6 +10871,15 @@ snapshots:
     dependencies:
       invariant: 2.2.4
       lodash: 4.17.21
+
+  sdk-environment@0.1.3:
+    dependencies:
+      '@aws-sdk/client-account': 3.1042.0
+      '@aws-sdk/client-iam': 3.1042.0
+      simple-in-memory-cache: 0.4.0
+      with-simple-cache: 0.15.3
+    transitivePeerDependencies:
+      - aws-crt
 
   seedrandom@3.0.5: {}
 
@@ -10746,9 +11132,9 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.2
 
-  test-fns@1.15.0(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4):
+  test-fns@1.15.0(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
     dependencies:
-      domain-objects: 0.31.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+      domain-objects: 0.31.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.41.11(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       helpful-errors: 1.5.3
       iso-time: 1.11.3
       uuid: 10.0.0
@@ -10757,8 +11143,8 @@ snapshots:
       - '@tensorflow/tfjs'
       - '@types/node'
       - aws-crt
+      - rhachet
       - ws
-      - zod
 
   test-fns@1.4.2:
     dependencies:
@@ -11007,6 +11393,19 @@ snapshots:
       simple-in-memory-cache: 0.4.0
       simple-on-disk-cache: 1.7.3
       type-fns: 1.21.2
+    transitivePeerDependencies:
+      - aws-crt
+
+  with-simple-cache@0.15.3:
+    dependencies:
+      '@ehmpathy/uni-time': 1.9.6
+      domain-objects: 0.31.7(@huggingface/transformers@4.0.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+      helpful-errors: 1.5.3
+      procedure-fns: 1.0.1
+      serde-fns: 1.3.1
+      simple-in-memory-cache: 0.4.0
+      simple-on-disk-cache: 1.7.3
+      type-fns: 1.21.0
     transitivePeerDependencies:
       - aws-crt
 

--- a/src/domain.objects/LogOutlet.ts
+++ b/src/domain.objects/LogOutlet.ts
@@ -1,3 +1,5 @@
+import type { Environment } from 'sdk-environment';
+
 import type { LogLevel } from './constants';
 
 /**
@@ -9,6 +11,7 @@ export interface LogEvent {
   timestamp: string;
   message: string;
   metadata?: Record<string, unknown>;
+  env?: Partial<Environment>;
 }
 
 /**

--- a/src/domain.objects/LogTrail.ts
+++ b/src/domain.objects/LogTrail.ts
@@ -1,4 +1,5 @@
 import type { Procedure, ProcedureContext } from 'domain-glossary-procedure';
+import type { Environment } from 'sdk-environment';
 
 import type { LogMethods } from '@src/domain.operations/genLogMethods';
 
@@ -35,7 +36,7 @@ export interface ContextLogTrail {
     /**
      * .what = environment context for log output
      */
-    env?: { commit: string };
+    env?: Partial<Environment>;
   };
 }
 

--- a/src/domain.operations/__snapshots__/genContextLogTrail.commit-null.integration.test.ts.snap
+++ b/src/domain.operations/__snapshots__/genContextLogTrail.commit-null.integration.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`journey: commit unavailable given: [case1] local dev without COMMIT_SHA when: [t0] context created with null commit then: logs work without env field 1`] = `
+exports[`journey: commit unavailable given: [case1] local dev without COMMIT_SHA when: [t0] context created with empty env then: logs work without env field 1`] = `
 {
   "level": "info",
   "message": "local dev log",

--- a/src/domain.operations/__snapshots__/genLogMethods.env-composability.integration.test.ts.snap
+++ b/src/domain.operations/__snapshots__/genLogMethods.env-composability.integration.test.ts.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`journey: genLogMethods with env composability given: [case1] global logger with env baked in when: [t0] wrapped operation logs via withLogTrail then: nested logs inherit env from global logger 1`] = `
+{
+  "env": {
+    "commit": "main@abc123",
+  },
+  "level": "info",
+  "message": "processOrder.progress: order processed",
+  "metadata": "{"orderId":"ord_456"}",
+  "timestamp": "[masked]",
+  "trail": {
+    "stack": [
+      "processOrder",
+    ],
+  },
+}
+`;
+
+exports[`journey: genLogMethods with env composability given: [case2] env precedence: genContextLogTrail env vs inherited when: [t0] genContextLogTrail provides different env then: per-request env wins over inherited env 1`] = `
+{
+  "env": {
+    "commit": "request@222",
+  },
+  "level": "info",
+  "message": "handleRequest.progress: request handled",
+  "metadata": undefined,
+  "timestamp": "[masked]",
+  "trail": {
+    "exid": "req_xyz",
+    "stack": [
+      "handleRequest",
+    ],
+  },
+}
+`;
+
+exports[`journey: genLogMethods with env composability given: [case3] global logger without trail, just env when: [t0] direct log call (no withLogTrail) then: log includes env.commit 1`] = `
+{
+  "env": {
+    "commit": "deploy@v1.2.3",
+  },
+  "level": "info",
+  "message": "server started",
+  "metadata": "{"port":3000}",
+  "timestamp": "[masked]",
+}
+`;

--- a/src/domain.operations/__snapshots__/genLogMethods.env-global.acceptance.test.ts.snap
+++ b/src/domain.operations/__snapshots__/genLogMethods.env-global.acceptance.test.ts.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`journey: global env.commit flows through all log paths given: [case1] person sets env.commit globally when: [t0] they call the logger directly then: commit is logged with it 1`] = `
+{
+  "env": {
+    "commit": "global@abc123",
+  },
+  "level": "info",
+  "message": "direct log call",
+  "metadata": "{"action":"boot"}",
+  "timestamp": "[masked]",
+}
+`;
+
+exports[`journey: global env.commit flows through all log paths given: [case1] person sets env.commit globally when: [t1] they pass the logger into a withLogTrail-wrapped function then: context.log.info logs the global env 1`] = `
+{
+  "env": {
+    "commit": "global@abc123",
+  },
+  "level": "info",
+  "message": "sayHello.progress: hello from wrapped function",
+  "metadata": undefined,
+  "timestamp": "[masked]",
+  "trail": {
+    "stack": [
+      "sayHello",
+    ],
+  },
+}
+`;
+
+exports[`journey: global env.commit flows through all log paths given: [case1] person sets env.commit globally when: [t2] they pass the logger into a genContextLogTrail that has its own env supplied then: the more specific newly supplied env wins, whenever context.log.info is called 1`] = `
+{
+  "env": {
+    "commit": "request@xyz789",
+  },
+  "level": "info",
+  "message": "via request context",
+  "metadata": "{"handler":"api"}",
+  "timestamp": "[masked]",
+  "trail": {
+    "exid": "req_002",
+    "stack": [],
+  },
+}
+`;
+
+exports[`journey: global env.commit flows through all log paths given: [case1] person sets env.commit globally when: [t2] they pass the logger into a genContextLogTrail that has its own env supplied then: the original env is preserved, whenever log is called directly 1`] = `
+{
+  "env": {
+    "commit": "global@abc123",
+  },
+  "level": "info",
+  "message": "global log after request",
+  "metadata": undefined,
+  "timestamp": "[masked]",
+}
+`;

--- a/src/domain.operations/__snapshots__/genLogMethods.test.ts.snap
+++ b/src/domain.operations/__snapshots__/genLogMethods.test.ts.snap
@@ -28,3 +28,15 @@ exports[`genLogMethods given: [case1] outlets provided when: [t0] log methods ca
   },
 ]
 `;
+
+exports[`genLogMethods given: [case3] env provided when: [t0] log methods called then: passes env to each log method 1`] = `
+[
+  {
+    "envCommit": "main@abc123",
+    "hasEnv": true,
+    "hasTimestamp": true,
+    "level": "info",
+    "message": "info message",
+  },
+]
+`;

--- a/src/domain.operations/formatLogContentsForEnvironment.ts
+++ b/src/domain.operations/formatLogContentsForEnvironment.ts
@@ -1,4 +1,5 @@
 import { UnexpectedCodePathError } from 'helpful-errors';
+import type { Environment } from 'sdk-environment';
 
 import {
   type LogLevel,
@@ -21,7 +22,7 @@ export const formatLogContentsForEnvironment = ({
   message: string;
   metadata?: Record<string, any>;
   trail?: LogTrail;
-  env?: { commit: string };
+  env?: Partial<Environment>;
 }) => {
   const environment = identifyEnvironment();
 

--- a/src/domain.operations/genContextLogTrail.all-log-levels.integration.test.ts
+++ b/src/domain.operations/genContextLogTrail.all-log-levels.integration.test.ts
@@ -16,7 +16,7 @@ describe('journey: all log levels include trail', () => {
         const context = genContextLogTrail({
           trail: { exid: 'req_abc123', stack: [] },
           env: { commit: 'a1b2c3d' },
-          minimalLogLevel: LogLevel.DEBUG,
+          level: { minimum: LogLevel.DEBUG },
         });
 
         context.log.debug('debug message', { detail: 'verbose' });

--- a/src/domain.operations/genContextLogTrail.commit-null.integration.test.ts
+++ b/src/domain.operations/genContextLogTrail.commit-null.integration.test.ts
@@ -9,13 +9,13 @@ const maskTimestamp = (log: Record<string, unknown>) => ({
 
 describe('journey: commit unavailable', () => {
   given('[case1] local dev without COMMIT_SHA', () => {
-    when('[t0] context created with null commit', () => {
+    when('[t0] context created with empty env', () => {
       then('logs work without env field', () => {
         const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 
         const context = genContextLogTrail({
           trail: { exid: 'req_abc123', stack: [] },
-          env: { commit: null },
+          env: {},
         });
 
         context.log.info('local dev log');

--- a/src/domain.operations/genContextLogTrail.test.ts
+++ b/src/domain.operations/genContextLogTrail.test.ts
@@ -124,13 +124,13 @@ describe('genContextLogTrail', () => {
     });
   });
 
-  given('[case5] env.commit is null', () => {
+  given('[case5] env.commit is undefined', () => {
     when('[t0] log method is called', () => {
       then('output omits env object', () => {
         const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
         const context = genContextLogTrail({
           trail: { exid: 'req_abc', stack: [] },
-          env: { commit: null },
+          env: {},
         });
         context.log.info('test message');
         expect(consoleSpy).toHaveBeenCalled();
@@ -150,7 +150,7 @@ describe('genContextLogTrail', () => {
         const context = genContextLogTrail({
           trail: { exid: 'req_abc', stack: [] },
           env: { commit: 'a1b2c3d' },
-          minimalLogLevel: LogLevel.DEBUG,
+          level: { minimum: LogLevel.DEBUG },
         });
 
         context.log.debug('debug msg');

--- a/src/domain.operations/genContextLogTrail.ts
+++ b/src/domain.operations/genContextLogTrail.ts
@@ -1,3 +1,5 @@
+import type { Environment } from 'sdk-environment';
+
 import { LogLevel } from '@src/domain.objects/constants';
 import type { ContextLogTrail, LogTrail } from '@src/domain.objects/LogTrail';
 
@@ -11,7 +13,7 @@ import { getRecommendedMinimalLogLevelForEnvironment } from './getRecommendedMin
 export const genContextLogTrail = ({
   trail,
   env,
-  minimalLogLevel = getRecommendedMinimalLogLevelForEnvironment(),
+  level,
 }: {
   /**
    * .what = the trail context for log correlation
@@ -26,26 +28,25 @@ export const genContextLogTrail = ({
    * .what = the environment context
    * .why = forces caller to explicitly provide or pass null
    */
-  env: {
-    commit: string | null;
-  } | null;
+  env: Partial<Environment> | null;
 
   /**
    * .what = the minimum log level to emit
    * .why = allows filter of logs by level
    */
-  minimalLogLevel?: LogLevel;
+  level?: { minimum?: LogLevel };
 }): ContextLogTrail => {
+  // derive minimal log level
+  const minimalLogLevel =
+    level?.minimum ?? getRecommendedMinimalLogLevelForEnvironment();
+
   // build the trail object: only include if provided
   const trailForLog: LogTrail | undefined = trail
     ? { exid: trail.exid, stack: trail.stack }
     : undefined;
 
-  // build the env object: only include if commit is not null
-  const envForLog: { commit: string } | undefined =
-    env?.commit !== null && env?.commit !== undefined
-      ? { commit: env.commit }
-      : undefined;
+  // build the env object: pass through if provided
+  const envForLog: Partial<Environment> | undefined = env ?? undefined;
 
   // generate the log methods with trail/env injected
   const logMethods = {

--- a/src/domain.operations/genLogMethods.env-composability.integration.test.ts
+++ b/src/domain.operations/genLogMethods.env-composability.integration.test.ts
@@ -1,12 +1,12 @@
 import { given, then, when } from 'test-fns';
 
+import type { ContextLogTrail } from '../domain.objects/LogTrail';
 import {
   genContextLogTrail,
   genLogMethods,
   LogLevel,
   withLogTrail,
 } from '../index';
-import type { ContextLogTrail } from '../domain.objects/LogTrail';
 
 const maskTimestamp = (log: Record<string, unknown>) => ({
   ...log,

--- a/src/domain.operations/genLogMethods.env-composability.integration.test.ts
+++ b/src/domain.operations/genLogMethods.env-composability.integration.test.ts
@@ -1,0 +1,129 @@
+import { given, then, when } from 'test-fns';
+
+import {
+  genContextLogTrail,
+  genLogMethods,
+  LogLevel,
+  withLogTrail,
+} from '../index';
+import type { ContextLogTrail } from '../domain.objects/LogTrail';
+
+const maskTimestamp = (log: Record<string, unknown>) => ({
+  ...log,
+  timestamp: '[masked]',
+});
+
+describe('journey: genLogMethods with env composability', () => {
+  given('[case1] global logger with env baked in', () => {
+    when('[t0] wrapped operation logs via withLogTrail', () => {
+      then('nested logs inherit env from global logger', () => {
+        const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+        // the core wish: global singleton with env, no trail ceremony
+        const globalLog = genLogMethods({
+          level: { minimum: LogLevel.DEBUG },
+          env: { commit: 'main@abc123' },
+        });
+
+        // create context that withLogTrail expects
+        const context: ContextLogTrail = {
+          log: {
+            ...globalLog,
+            trail: undefined, // no trail for global logger
+          },
+        };
+
+        // wrap an operation
+        const processOrder = withLogTrail(
+          async (input: { orderId: string }, ctx: typeof context) => {
+            ctx.log.info('order processed', { orderId: input.orderId });
+            return { success: true };
+          },
+          { name: 'processOrder' },
+        );
+
+        processOrder({ orderId: 'ord_456' }, context);
+
+        // find the progress log
+        const progressLog = consoleSpy.mock.calls.find((call) =>
+          call[0]?.message?.includes('order processed'),
+        )?.[0];
+
+        expect(maskTimestamp(progressLog)).toMatchSnapshot();
+
+        // explicit assertion: env is inherited
+        expect(progressLog.env).toEqual({ commit: 'main@abc123' });
+
+        consoleSpy.mockRestore();
+      });
+    });
+  });
+
+  given('[case2] env precedence: genContextLogTrail env vs inherited', () => {
+    when('[t0] genContextLogTrail provides different env', () => {
+      then('per-request env wins over inherited env', () => {
+        const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+        // global logger with one commit
+        const globalLog = genLogMethods({
+          level: { minimum: LogLevel.DEBUG },
+          env: { commit: 'global@111' },
+        });
+
+        // per-request context with different commit
+        const requestContext = genContextLogTrail({
+          trail: { exid: 'req_xyz', stack: [] },
+          env: { commit: 'request@222' }, // different from global
+          level: { minimum: LogLevel.DEBUG },
+        });
+
+        // wrap an operation
+        const handleRequest = withLogTrail(
+          async (_input: unknown, ctx: typeof requestContext) => {
+            ctx.log.info('request handled');
+            return { done: true };
+          },
+          { name: 'handleRequest' },
+        );
+
+        handleRequest({}, requestContext);
+
+        // find the progress log
+        const progressLog = consoleSpy.mock.calls.find((call) =>
+          call[0]?.message?.includes('request handled'),
+        )?.[0];
+
+        expect(maskTimestamp(progressLog)).toMatchSnapshot();
+
+        // explicit assertion: per-request env wins
+        expect(progressLog.env).toEqual({ commit: 'request@222' });
+
+        consoleSpy.mockRestore();
+      });
+    });
+  });
+
+  given('[case3] global logger without trail, just env', () => {
+    when('[t0] direct log call (no withLogTrail)', () => {
+      then('log includes env.commit', () => {
+        const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+        // the simplest case: genLogMethods + env, no trail
+        const log = genLogMethods({
+          level: { minimum: LogLevel.DEBUG },
+          env: { commit: 'deploy@v1.2.3' },
+        });
+
+        log.info('server started', { port: 3000 });
+
+        const logOutput = consoleSpy.mock.calls[0]?.[0];
+        expect(maskTimestamp(logOutput)).toMatchSnapshot();
+
+        // explicit assertion: env is present
+        expect(logOutput.env).toEqual({ commit: 'deploy@v1.2.3' });
+
+        consoleSpy.mockRestore();
+      });
+    });
+  });
+});

--- a/src/domain.operations/genLogMethods.env-global.acceptance.test.ts
+++ b/src/domain.operations/genLogMethods.env-global.acceptance.test.ts
@@ -1,0 +1,97 @@
+import { given, then, when } from 'test-fns';
+
+import { genContextLogTrail, genLogMethods, LogLevel, withLogTrail } from '../index';
+import type { ContextLogTrail } from '../domain.objects/LogTrail';
+
+const maskTimestamp = (log: Record<string, unknown>) => ({
+  ...log,
+  timestamp: '[masked]',
+});
+
+describe('journey: global env.commit flows through all log paths', () => {
+  given('[case1] person sets env.commit globally', () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    // setup: global logger with env baked in
+    const globalLog = genLogMethods({
+      level: { minimum: LogLevel.DEBUG },
+      env: { commit: 'global@abc123' },
+    });
+
+    afterEach(() => consoleSpy.mockClear());
+    afterAll(() => consoleSpy.mockRestore());
+
+    when('[t0] they call the logger directly', () => {
+      then('commit is logged with it', () => {
+        globalLog.info('direct log call', { action: 'boot' });
+
+        const logOutput = consoleSpy.mock.calls[0]?.[0];
+        expect(maskTimestamp(logOutput)).toMatchSnapshot();
+        expect(logOutput.env).toEqual({ commit: 'global@abc123' });
+      });
+    });
+
+    when('[t1] they pass the logger into a withLogTrail-wrapped function', () => {
+      then('context.log.info logs the global env', () => {
+        // wrap a function with withLogTrail
+        const sayHello = withLogTrail(
+          (_input: unknown, context: ContextLogTrail) => {
+            context.log.info('hello from wrapped function');
+            return { greeted: true };
+          },
+          { name: 'sayHello' },
+        );
+
+        // pass genLogMethods as the log context
+        sayHello({}, { log: { ...globalLog, trail: undefined } });
+
+        // find the progress log (not the input/output logs)
+        const progressLog = consoleSpy.mock.calls.find((call) =>
+          call[0]?.message?.includes('hello from wrapped function'),
+        )?.[0];
+
+        expect(maskTimestamp(progressLog)).toMatchSnapshot();
+        expect(progressLog.env).toEqual({ commit: 'global@abc123' });
+      });
+    });
+
+    when('[t2] they pass the logger into a genContextLogTrail that has its own env supplied', () => {
+      then('the more specific newly supplied env wins, whenever context.log.info is called', () => {
+        // create per-request context with different env
+        const requestContext = genContextLogTrail({
+          trail: { exid: 'req_002', stack: [] },
+          env: { commit: 'request@xyz789' }, // overrides global
+          level: { minimum: LogLevel.DEBUG },
+        });
+
+        requestContext.log.info('via request context', { handler: 'api' });
+
+        const logOutput = consoleSpy.mock.calls[0]?.[0];
+        expect(maskTimestamp(logOutput)).toMatchSnapshot();
+        expect(logOutput.env).toEqual({ commit: 'request@xyz789' });
+      });
+
+      then('the original env is preserved, whenever log is called directly', () => {
+        // first: call via request context (different env)
+        const requestContext = genContextLogTrail({
+          trail: { exid: 'req_003', stack: [] },
+          env: { commit: 'request@xyz789' },
+          level: { minimum: LogLevel.DEBUG },
+        });
+        requestContext.log.info('request log');
+
+        // second: call global logger directly
+        globalLog.info('global log after request');
+
+        // verify request log has request env
+        const requestLogOutput = consoleSpy.mock.calls[0]?.[0];
+        expect(requestLogOutput.env).toEqual({ commit: 'request@xyz789' });
+
+        // verify global log still has global env
+        const globalLogOutput = consoleSpy.mock.calls[1]?.[0];
+        expect(maskTimestamp(globalLogOutput)).toMatchSnapshot();
+        expect(globalLogOutput.env).toEqual({ commit: 'global@abc123' });
+      });
+    });
+  });
+});

--- a/src/domain.operations/genLogMethods.env-global.acceptance.test.ts
+++ b/src/domain.operations/genLogMethods.env-global.acceptance.test.ts
@@ -1,7 +1,12 @@
 import { given, then, when } from 'test-fns';
 
-import { genContextLogTrail, genLogMethods, LogLevel, withLogTrail } from '../index';
 import type { ContextLogTrail } from '../domain.objects/LogTrail';
+import {
+  genContextLogTrail,
+  genLogMethods,
+  LogLevel,
+  withLogTrail,
+} from '../index';
 
 const maskTimestamp = (log: Record<string, unknown>) => ({
   ...log,
@@ -31,67 +36,79 @@ describe('journey: global env.commit flows through all log paths', () => {
       });
     });
 
-    when('[t1] they pass the logger into a withLogTrail-wrapped function', () => {
-      then('context.log.info logs the global env', () => {
-        // wrap a function with withLogTrail
-        const sayHello = withLogTrail(
-          (_input: unknown, context: ContextLogTrail) => {
-            context.log.info('hello from wrapped function');
-            return { greeted: true };
+    when(
+      '[t1] they pass the logger into a withLogTrail-wrapped function',
+      () => {
+        then('context.log.info logs the global env', () => {
+          // wrap a function with withLogTrail
+          const sayHello = withLogTrail(
+            (_input: unknown, context: ContextLogTrail) => {
+              context.log.info('hello from wrapped function');
+              return { greeted: true };
+            },
+            { name: 'sayHello' },
+          );
+
+          // pass genLogMethods as the log context
+          sayHello({}, { log: { ...globalLog, trail: undefined } });
+
+          // find the progress log (not the input/output logs)
+          const progressLog = consoleSpy.mock.calls.find((call) =>
+            call[0]?.message?.includes('hello from wrapped function'),
+          )?.[0];
+
+          expect(maskTimestamp(progressLog)).toMatchSnapshot();
+          expect(progressLog.env).toEqual({ commit: 'global@abc123' });
+        });
+      },
+    );
+
+    when(
+      '[t2] they pass the logger into a genContextLogTrail that has its own env supplied',
+      () => {
+        then(
+          'the more specific newly supplied env wins, whenever context.log.info is called',
+          () => {
+            // create per-request context with different env
+            const requestContext = genContextLogTrail({
+              trail: { exid: 'req_002', stack: [] },
+              env: { commit: 'request@xyz789' }, // overrides global
+              level: { minimum: LogLevel.DEBUG },
+            });
+
+            requestContext.log.info('via request context', { handler: 'api' });
+
+            const logOutput = consoleSpy.mock.calls[0]?.[0];
+            expect(maskTimestamp(logOutput)).toMatchSnapshot();
+            expect(logOutput.env).toEqual({ commit: 'request@xyz789' });
           },
-          { name: 'sayHello' },
         );
 
-        // pass genLogMethods as the log context
-        sayHello({}, { log: { ...globalLog, trail: undefined } });
+        then(
+          'the original env is preserved, whenever log is called directly',
+          () => {
+            // first: call via request context (different env)
+            const requestContext = genContextLogTrail({
+              trail: { exid: 'req_003', stack: [] },
+              env: { commit: 'request@xyz789' },
+              level: { minimum: LogLevel.DEBUG },
+            });
+            requestContext.log.info('request log');
 
-        // find the progress log (not the input/output logs)
-        const progressLog = consoleSpy.mock.calls.find((call) =>
-          call[0]?.message?.includes('hello from wrapped function'),
-        )?.[0];
+            // second: call global logger directly
+            globalLog.info('global log after request');
 
-        expect(maskTimestamp(progressLog)).toMatchSnapshot();
-        expect(progressLog.env).toEqual({ commit: 'global@abc123' });
-      });
-    });
+            // verify request log has request env
+            const requestLogOutput = consoleSpy.mock.calls[0]?.[0];
+            expect(requestLogOutput.env).toEqual({ commit: 'request@xyz789' });
 
-    when('[t2] they pass the logger into a genContextLogTrail that has its own env supplied', () => {
-      then('the more specific newly supplied env wins, whenever context.log.info is called', () => {
-        // create per-request context with different env
-        const requestContext = genContextLogTrail({
-          trail: { exid: 'req_002', stack: [] },
-          env: { commit: 'request@xyz789' }, // overrides global
-          level: { minimum: LogLevel.DEBUG },
-        });
-
-        requestContext.log.info('via request context', { handler: 'api' });
-
-        const logOutput = consoleSpy.mock.calls[0]?.[0];
-        expect(maskTimestamp(logOutput)).toMatchSnapshot();
-        expect(logOutput.env).toEqual({ commit: 'request@xyz789' });
-      });
-
-      then('the original env is preserved, whenever log is called directly', () => {
-        // first: call via request context (different env)
-        const requestContext = genContextLogTrail({
-          trail: { exid: 'req_003', stack: [] },
-          env: { commit: 'request@xyz789' },
-          level: { minimum: LogLevel.DEBUG },
-        });
-        requestContext.log.info('request log');
-
-        // second: call global logger directly
-        globalLog.info('global log after request');
-
-        // verify request log has request env
-        const requestLogOutput = consoleSpy.mock.calls[0]?.[0];
-        expect(requestLogOutput.env).toEqual({ commit: 'request@xyz789' });
-
-        // verify global log still has global env
-        const globalLogOutput = consoleSpy.mock.calls[1]?.[0];
-        expect(maskTimestamp(globalLogOutput)).toMatchSnapshot();
-        expect(globalLogOutput.env).toEqual({ commit: 'global@abc123' });
-      });
-    });
+            // verify global log still has global env
+            const globalLogOutput = consoleSpy.mock.calls[1]?.[0];
+            expect(maskTimestamp(globalLogOutput)).toMatchSnapshot();
+            expect(globalLogOutput.env).toEqual({ commit: 'global@abc123' });
+          },
+        );
+      },
+    );
   });
 });

--- a/src/domain.operations/genLogMethods.test.ts
+++ b/src/domain.operations/genLogMethods.test.ts
@@ -60,4 +60,65 @@ describe('genLogMethods', () => {
       });
     });
   });
+
+  given('[case3] env provided', () => {
+    const createMockOutlet = (): LogOutlet & { events: LogEvent[] } => {
+      const events: LogEvent[] = [];
+      return {
+        events,
+        send: (event: LogEvent) => events.push(event),
+        flush: async () => {},
+      };
+    };
+
+    when('[t0] log methods called', () => {
+      then('passes env to each log method', () => {
+        const outlet = createMockOutlet();
+        const log = genLogMethods({
+          level: { minimum: LogLevel.DEBUG },
+          outlets: [outlet],
+          env: { commit: 'main@abc123' },
+        });
+
+        log.info('info message');
+
+        expect(outlet.events).toHaveLength(1);
+        expect(outlet.events[0]?.env).toEqual({ commit: 'main@abc123' });
+        // snapshot for vibecheck: shows full log event structure with env
+        expect(
+          outlet.events.map((e) => ({
+            level: e.level,
+            message: e.message,
+            hasTimestamp: !!e.timestamp,
+            hasEnv: e.env !== undefined,
+            envCommit: e.env?.commit,
+          })),
+        ).toMatchSnapshot();
+      });
+
+      then('exposes env on LogMethods for withLogTrail composability', () => {
+        const log = genLogMethods({
+          env: { commit: 'main@abc123' },
+        });
+
+        expect(log.env).toEqual({ commit: 'main@abc123' });
+      });
+    });
+
+    when('[t1] env is null', () => {
+      then('env is omitted from log output', () => {
+        const outlet = createMockOutlet();
+        const log = genLogMethods({
+          level: { minimum: LogLevel.DEBUG },
+          outlets: [outlet],
+          env: null,
+        });
+
+        log.info('info message');
+
+        expect(outlet.events).toHaveLength(1);
+        expect(outlet.events[0]?.env).toBeUndefined();
+      });
+    });
+  });
 });

--- a/src/domain.operations/genLogMethods.ts
+++ b/src/domain.operations/genLogMethods.ts
@@ -1,3 +1,5 @@
+import type { Environment } from 'sdk-environment';
+
 import { LogLevel } from '@src/domain.objects/constants';
 import type { LogOutlet } from '@src/domain.objects/LogOutlet';
 
@@ -37,6 +39,12 @@ export interface LogMethods {
    * .what = internal config for log methods
    */
   readonly _: Readonly<{ level: LogLevel }>;
+
+  /**
+   * .what = the environment context baked into these log methods
+   * .why = enables withLogTrail to inherit env from outer log
+   */
+  readonly env?: Partial<Environment>;
 }
 
 /**
@@ -44,17 +52,23 @@ export interface LogMethods {
  * - allows you to specify the minimal log level to use for your application
  * - defaults to recommended levels for the environment
  * - allows you to specify outlets for log events to flow to external destinations
+ * - allows you to specify env for environment context (e.g., commit hash)
  */
 export const genLogMethods = ({
   level,
   outlets,
+  env,
 }: {
   level?: { minimum?: LogLevel };
   outlets?: LogOutlet[];
+  env?: Partial<Environment> | null;
 } = {}): LogMethods => {
   // derive minimal log level
   const derivedMinimalLogLevel =
     level?.minimum ?? getRecommendedMinimalLogLevelForEnvironment();
+
+  // convert null to undefined for internal use
+  const envForLog = env ?? undefined;
 
   // generate the methods
   return {
@@ -62,22 +76,27 @@ export const genLogMethods = ({
       level: LogLevel.ERROR,
       minimalLogLevel: derivedMinimalLogLevel,
       outlets,
+      env: envForLog,
     }),
     warn: generateLogMethod({
       level: LogLevel.WARN,
       minimalLogLevel: derivedMinimalLogLevel,
       outlets,
+      env: envForLog,
     }),
     info: generateLogMethod({
       level: LogLevel.INFO,
       minimalLogLevel: derivedMinimalLogLevel,
       outlets,
+      env: envForLog,
     }),
     debug: generateLogMethod({
       level: LogLevel.DEBUG,
       minimalLogLevel: derivedMinimalLogLevel,
       outlets,
+      env: envForLog,
     }),
     _: Object.freeze({ level: derivedMinimalLogLevel }),
+    env: envForLog,
   };
 };

--- a/src/domain.operations/generateLogMethod.ts
+++ b/src/domain.operations/generateLogMethod.ts
@@ -1,3 +1,5 @@
+import type { Environment } from 'sdk-environment';
+
 import { LogLevel } from '@src/domain.objects/constants';
 import type { LogEvent, LogOutlet } from '@src/domain.objects/LogOutlet';
 import type { LogTrail } from '@src/domain.objects/LogTrail';
@@ -35,7 +37,7 @@ export const generateLogMethod = ({
   level: LogLevel;
   minimalLogLevel: LogLevel;
   trail?: LogTrail;
-  env?: { commit: string };
+  env?: Partial<Environment>;
   outlets?: LogOutlet[];
 }) => {
   return (message: string, metadata?: object) => {
@@ -72,6 +74,7 @@ export const generateLogMethod = ({
         timestamp,
         message,
         metadata: metadata as Record<string, unknown> | undefined,
+        env,
       };
       for (const outlet of outlets) {
         outlet.send(event);

--- a/src/domain.operations/outlets/cloudwatch/__snapshots__/genCloudwatchOutlet.acceptance.test.ts.snap
+++ b/src/domain.operations/outlets/cloudwatch/__snapshots__/genCloudwatchOutlet.acceptance.test.ts.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`genCloudwatchOutlet given: [case1] cloudwatch outlet created when: [t0] send and flush called then: log event sent to cloudwatch 1`] = `
+{
+  "hasMetadata": true,
+  "hasTimestamp": true,
+  "level": "info",
+  "message": "test message from integration test",
+}
+`;
+
+exports[`genCloudwatchOutlet given: [case2] region parameter provided when: [t0] outlet created with explicit region then: uses explicit region over env vars 1`] = `
+{
+  "hasClose": true,
+  "hasFlush": true,
+  "hasSend": true,
+}
+`;
+
+exports[`genCloudwatchOutlet given: [case3] skipLogGroupCreation is true when: [t0] send and flush called without log group then: throws because log group absent 1`] = `
+{
+  "errorOnFlush": true,
+  "skipLogGroupCreation": true,
+}
+`;
+
+exports[`genCloudwatchOutlet given: [case4] multiple events batched when: [t0] multiple events sent and flushed then: all events appear in cloudwatch 1`] = `
+{
+  "eventCount": 5,
+  "eventStructures": [
+    {
+      "hasTimestamp": true,
+      "level": "info",
+      "messagePattern": true,
+    },
+    {
+      "hasTimestamp": true,
+      "level": "info",
+      "messagePattern": true,
+    },
+    {
+      "hasTimestamp": true,
+      "level": "info",
+      "messagePattern": true,
+    },
+    {
+      "hasTimestamp": true,
+      "level": "info",
+      "messagePattern": true,
+    },
+    {
+      "hasTimestamp": true,
+      "level": "info",
+      "messagePattern": true,
+    },
+  ],
+}
+`;

--- a/src/domain.operations/withLogTrail.stack-growth.integration.test.ts
+++ b/src/domain.operations/withLogTrail.stack-growth.integration.test.ts
@@ -16,7 +16,7 @@ describe('journey: withLogTrail grows stack automatically', () => {
         const context = genContextLogTrail({
           trail: { exid: 'req_abc123', stack: [] },
           env: { commit: 'a1b2c3d' },
-          minimalLogLevel: LogLevel.DEBUG,
+          level: { minimum: LogLevel.DEBUG },
         });
 
         const processOrder = withLogTrail(
@@ -47,7 +47,7 @@ describe('journey: withLogTrail grows stack automatically', () => {
         const context = genContextLogTrail({
           trail: { exid: 'req_abc123', stack: [] },
           env: { commit: 'a1b2c3d' },
-          minimalLogLevel: LogLevel.DEBUG,
+          level: { minimum: LogLevel.DEBUG },
         });
 
         const validateInventory = withLogTrail(

--- a/src/domain.operations/withLogTrail.test.ts
+++ b/src/domain.operations/withLogTrail.test.ts
@@ -3,7 +3,9 @@ import { LogLevel } from '@src/domain.objects/constants';
 import type { LogMethods } from './genLogMethods';
 import { withLogTrail } from './withLogTrail';
 
-const createMockLogMethods = (): LogMethods & {
+const createMockLogMethods = (options?: {
+  env?: { commit: string };
+}): LogMethods & {
   debug: jest.Mock;
   info: jest.Mock;
   warn: jest.Mock;
@@ -14,6 +16,7 @@ const createMockLogMethods = (): LogMethods & {
   warn: jest.fn(),
   error: jest.fn(),
   _: Object.freeze({ level: LogLevel.DEBUG }),
+  env: options?.env,
 });
 
 describe('withLogTrail', () => {
@@ -322,6 +325,46 @@ describe('withLogTrail', () => {
           expect.any(Object),
         );
       });
+    });
+  });
+
+  describe('env inheritance', () => {
+    it('should pass env from context.log to nested log methods', () => {
+      const mockLog = createMockLogMethods({ env: { commit: 'main@abc123' } });
+      let capturedContext: { log: { env?: { commit: string } } } | undefined;
+
+      const testFn = function testFunction(
+        input: string,
+        context: { log: { env?: { commit: string } } },
+      ) {
+        capturedContext = context;
+        return input.toUpperCase();
+      };
+      const wrapped = withLogTrail(testFn, {});
+
+      wrapped('hello', { log: mockLog });
+
+      // verify env is passed through to nested context
+      expect(capturedContext?.log.env).toEqual({ commit: 'main@abc123' });
+    });
+
+    it('should preserve env when no env is provided', () => {
+      const mockLog = createMockLogMethods(); // no env
+      let capturedContext: { log: { env?: { commit: string } } } | undefined;
+
+      const testFn = function testFunction(
+        input: string,
+        context: { log: { env?: { commit: string } } },
+      ) {
+        capturedContext = context;
+        return input.toUpperCase();
+      };
+      const wrapped = withLogTrail(testFn, {});
+
+      wrapped('hello', { log: mockLog });
+
+      // verify env is undefined when not provided
+      expect(capturedContext?.log.env).toBeUndefined();
     });
   });
 });

--- a/src/domain.operations/withLogTrail.test.ts
+++ b/src/domain.operations/withLogTrail.test.ts
@@ -1,4 +1,7 @@
+import type { Environment } from 'sdk-environment';
+
 import { LogLevel } from '@src/domain.objects/constants';
+import type { ContextLogTrail } from '@src/domain.objects/LogTrail';
 
 import type { LogMethods } from './genLogMethods';
 import { withLogTrail } from './withLogTrail';
@@ -331,13 +334,13 @@ describe('withLogTrail', () => {
   describe('env inheritance', () => {
     it('should pass env from context.log to nested log methods', () => {
       const mockLog = createMockLogMethods({ env: { commit: 'main@abc123' } });
-      let capturedContext: { log: { env?: { commit: string } } } | undefined;
+      let capturedEnv: Partial<Environment> | undefined;
 
       const testFn = function testFunction(
         input: string,
-        context: { log: { env?: { commit: string } } },
+        context: ContextLogTrail,
       ) {
-        capturedContext = context;
+        capturedEnv = context.log.env;
         return input.toUpperCase();
       };
       const wrapped = withLogTrail(testFn, {});
@@ -345,18 +348,18 @@ describe('withLogTrail', () => {
       wrapped('hello', { log: mockLog });
 
       // verify env is passed through to nested context
-      expect(capturedContext?.log.env).toEqual({ commit: 'main@abc123' });
+      expect(capturedEnv).toEqual({ commit: 'main@abc123' });
     });
 
     it('should preserve env when no env is provided', () => {
       const mockLog = createMockLogMethods(); // no env
-      let capturedContext: { log: { env?: { commit: string } } } | undefined;
+      let capturedEnv: Partial<Environment> | undefined;
 
       const testFn = function testFunction(
         input: string,
-        context: { log: { env?: { commit: string } } },
+        context: ContextLogTrail,
       ) {
-        capturedContext = context;
+        capturedEnv = context.log.env;
         return input.toUpperCase();
       };
       const wrapped = withLogTrail(testFn, {});
@@ -364,7 +367,7 @@ describe('withLogTrail', () => {
       wrapped('hello', { log: mockLog });
 
       // verify env is undefined when not provided
-      expect(capturedContext?.log.env).toBeUndefined();
+      expect(capturedEnv).toBeUndefined();
     });
   });
 });

--- a/src/domain.operations/withLogTrail.ts
+++ b/src/domain.operations/withLogTrail.ts
@@ -5,6 +5,7 @@ import type {
 } from 'domain-glossary-procedure';
 import { UnexpectedCodePathError } from 'helpful-errors';
 import { type IsoDuration, toMilliseconds } from 'iso-time';
+import type { Environment } from 'sdk-environment';
 import { isAPromise, type Literalize } from 'type-fns';
 
 import { LogLevel } from '@src/domain.objects/constants';
@@ -184,7 +185,7 @@ export const withLogTrail = <TInput, TContext extends ContextLogTrail, TOutput>(
     // define the context.log method that will be given to the logic
     const logMethodsWithContext: LogMethods & { _orig: LogMethods } & {
       trail: LogTrail;
-      env?: { commit: string };
+      env?: Partial<Environment>;
     } = {
       // add the trail, env, and config
       trail: updatedTrail,


### PR DESCRIPTION
feat(env): add env parameter to genLogMethods for global commit tagging

- genLogMethods({ env }) accepts Partial<Environment> for global env context
- env.commit flows through withLogTrail-wrapped functions
- genContextLogTrail env overrides inherited env (more specific wins)
- LogMethods.env exposed for composability
- LogEvent includes env for outlet forwarding
- updated genContextLogTrail to use level: { minimum } shape for consistency

---
🐢🌊 surfed in by seaturtle[bot]