### PR TITLE
fix(cicd): hardcode aws oidc role arn in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/.test.yml
     with:
       creds-aws-region: us-east-1
-      creds-aws-role-arn: ${{ vars.CREDS_CICD_AWS_DEV_OIDC_ROLE_ARN }} # use aws auth via oidc, if this repo supplies it
+      creds-aws-role-arn: arn:aws:iam::805192865516:role/ehmpathy-demo-oidc
     secrets: inherit # keyrack firewall in .test.yml filters to declared keys
 
   publish:


### PR DESCRIPTION
fix(cicd): hardcode aws oidc role arn in publish workflow

- publish.yml was using vars.CREDS_CICD_AWS_DEV_OIDC_ROLE_ARN which is not set
- hardcode the arn like test.yml does for consistency
- fixes publish workflow failing on tag push

---
🐢🌊 surfed in by seaturtle[bot]